### PR TITLE
workflow: update golangci lint install script link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
 	@ln -sf golangci-lint-${GOLANGCI_VERSION} bin/golangci-lint
 bin/golangci-lint-${GOLANGCI_VERSION}:
 	@mkdir -p bin
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b ./bin/ v${GOLANGCI_VERSION}
 	@mv bin/golangci-lint $@
 
 .PHONY: lint


### PR DESCRIPTION
replacing previous deprecated script with the command from https://golangci-lint.run/usage/install/#other-ci
```
this script is deprecated, please do not use it anymore. check https://github.com/goreleaser/godownloader/issues/207
```