### PR TITLE
Adds 'services_to_trace' parameter to Kong plugin.

### DIFF
--- a/plugins/gateway/kong/deploy/kongPlugin.yaml
+++ b/plugins/gateway/kong/deploy/kongPlugin.yaml
@@ -5,3 +5,8 @@ metadata:
 plugin: kong-plugin
 config:
   host: {{UPSTREAM_TELEMETRY_HOST_NAME}}
+  services_to_trace:
+  - service: "*"
+    port: 0
+  # - service: "example-microservice.test"
+  #   port: 9876


### PR DESCRIPTION
It's a list of service/port to trace.

A service is like this:
{
  "service": "name of the service known by kong",
  "port": 6544
}

There is a specific catchall service that means "all services":
{
  "service": "*",
  "port": 0
}

If the list of services is empty, then no traces are dumped.