### PR TITLE
Fix bug when invalid spec is stored in DB

### DIFF
--- a/backend/pkg/rest/apiinventory_upload_spec.go
+++ b/backend/pkg/rest/apiinventory_upload_spec.go
@@ -66,20 +66,6 @@ func (s *Server) PutAPIInventoryAPIIDSpecsProvidedSpec(params operations.PutAPII
 		pathToPathID[path] = uuid.NewV4().String()
 	}
 
-	specInfo, err := createSpecInfo(params.Body.RawSpec, pathToPathID)
-	if err != nil {
-		log.Errorf("Failed to create spec info. %v", err)
-		return operations.NewPutAPIInventoryAPIIDSpecsProvidedSpecDefault(http.StatusInternalServerError)
-	}
-
-	// Save the provided spec in the DB without expanding the ref fields
-	if err = s.dbHandler.APIInventoryTable().PutAPISpec(uint(params.APIID), params.Body.RawSpec, specInfo, database.ProvidedSpecType); err != nil {
-		// TODO: need to handle errors
-		// https://github.com/go-gorm/gorm/blob/master/errors.go
-		log.Errorf("Failed to put provided API spec. %v", err)
-		return operations.NewPutAPIInventoryAPIIDSpecsProvidedSpecDefault(http.StatusInternalServerError)
-	}
-
 	// Expands the ref fields in the analyzed spec document
 	jsonSpecBytes, err = getExpandedSpec(analyzed)
 	if err != nil {
@@ -95,6 +81,20 @@ func (s *Server) PutAPIInventoryAPIIDSpecsProvidedSpec(params operations.PutAPII
 
 	// Since we don't have a mapping between events paths to the parametrized path,
 	// We will not set the old events with provided path IDs
+
+	specInfo, err := createSpecInfo(params.Body.RawSpec, pathToPathID)
+	if err != nil {
+		log.Errorf("Failed to create spec info. %v", err)
+		return operations.NewPutAPIInventoryAPIIDSpecsProvidedSpecDefault(http.StatusInternalServerError)
+	}
+
+	// Save the provided spec in the DB without expanding the ref fields
+	if err = s.dbHandler.APIInventoryTable().PutAPISpec(uint(params.APIID), params.Body.RawSpec, specInfo, database.ProvidedSpecType); err != nil {
+		// TODO: need to handle errors
+		// https://github.com/go-gorm/gorm/blob/master/errors.go
+		log.Errorf("Failed to put provided API spec. %v", err)
+		return operations.NewPutAPIInventoryAPIIDSpecsProvidedSpecDefault(http.StatusInternalServerError)
+	}
 
 	return operations.NewPutAPIInventoryAPIIDSpecsProvidedSpecCreated().
 		WithPayload(&models.RawSpec{RawSpec: params.Body.RawSpec})


### PR DESCRIPTION
Before this fix, an uploaded spec was:

1. validated by apiclarity
2. stored in the DB
3. refs - expanded
4. given to the speculator library
5. validated by the speculator library

If the speculator doesn't validate the expanded spec, then an error is
returned up to the UI, but the spec is already stored in DB at step 2.

Why would the ref-expansion step would create a invalid spec in step 3,
but was considered as valid in step 1 ?

Let's take the following spec:
```json
{
   "swagger":"2.0",
   "info":{
      "version":"",
      "title":"User",
      "description":"Provide Customer login, register, retrieval, as well as card and address retrieval",
      "license":{
         "name":"MIT",
         "url":"http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
      }
   },
```
here, `info.version` is defined as an empty string. This spec is
valid (step 1.)

When expanded in `getExpandedSpec()`, the spec is also Marshal'ed to
bytes. During this Marshaling, the 'version.info' field is completly
removed because the go-openapi `InfoProps` struct tag of the `Version`
field is 'omitempty".

```go
type InfoProps struct {
	Description    string       `json:"description,omitempty"`
	Title          string       `json:"title,omitempty"`
	TermsOfService string       `json:"termsOfService,omitempty"`
	Contact        *ContactInfo `json:"contact,omitempty"`
	License        *License     `json:"license,omitempty"`
	Version        string       `json:"version,omitempty"`
}
```

A solution is to store the api in the DB only when valid according to
APIClarity and according to the speculator.