### PR TITLE
Revert "Simpler api3/generate.sh file"

### DIFF
--- a/api3/generate.sh
+++ b/api3/generate.sh
@@ -1,7 +1,9 @@
 #!/bin/bash	
 
 (cd ../tools/spec-aggregator && go run main.go)
-go generate -v ./...
+(cd ./common && go generate)
+(cd ./global && go generate)
+(cd ./notifications && go generate)
 
 if [[ $1 == "--verify" ]]  ; then
     diffs=$(git status --porcelain)


### PR DESCRIPTION
This reverts commit 122e228879e1e5e2cf16d8a456dc169ae7228b5a.
The order is important, "common" needs to be generated first.