### PR TITLE
feat: new Fuzzer module report with highestSeverity

### DIFF
--- a/api3/global/openapi.gen.yaml
+++ b/api3/global/openapi.gen.yaml
@@ -590,6 +590,8 @@ components:
             $ref: ../common/openapi.yaml#/components/schemas/APIFinding
           title: Findings list
           type: array
+        highestSeverity:
+          $ref: ../common/openapi.yaml#/components/schemas/Severity
         operation:
           $ref: ../common/openapi.yaml#/components/schemas/MethodAndPath
         requestsCount:
@@ -598,8 +600,10 @@ components:
           title: Request count to the opea
           type: integer
       required:
+      - operation
       - requestsCount
       - findings
+      - highestSeverity
       title: Report tag operation
       type: object
     FuzzingReportPath:
@@ -620,6 +624,8 @@ components:
     FuzzingReportTag:
       description: Report tag item
       properties:
+        highestSeverity:
+          $ref: ../common/openapi.yaml#/components/schemas/Severity
         name:
           description: Tag name
           title: Tag name
@@ -632,6 +638,7 @@ components:
       required:
       - name
       - operations
+      - highestSeverity
       title: Report tag item
       type: object
     FuzzingStatusAndReport:
@@ -784,6 +791,8 @@ components:
       properties:
         apiID:
           $ref: ../common/openapi.yaml#/components/schemas/ApiID
+        highestSeverity:
+          $ref: ../common/openapi.yaml#/components/schemas/Severity
         starttime:
           description: Timestamp of the start of the test
           format: int64
@@ -804,6 +813,7 @@ components:
       - starttime
       - status
       - tags
+      - highestSeverity
       title: Short Test Report
       type: object
     SpecType:

--- a/api3/global/restapi.gen.go
+++ b/api3/global/restapi.gen.go
@@ -264,8 +264,11 @@ type FuzzingReportItem struct {
 
 // Report tag operation
 type FuzzingReportOperation struct {
-	Findings  []externalRef0.APIFinding   `json:"findings"`
-	Operation *externalRef0.MethodAndPath `json:"operation,omitempty"`
+	Findings []externalRef0.APIFinding `json:"findings"`
+
+	// Severity of a finding
+	HighestSeverity externalRef0.Severity      `json:"highestSeverity"`
+	Operation       externalRef0.MethodAndPath `json:"operation"`
 
 	// Request count to this operation item during the test
 	RequestsCount int32 `json:"requestsCount"`
@@ -282,6 +285,9 @@ type FuzzingReportPath struct {
 
 // Report tag item
 type FuzzingReportTag struct {
+	// Severity of a finding
+	HighestSeverity externalRef0.Severity `json:"highestSeverity"`
+
 	// Tag name
 	Name       string                   `json:"name"`
 	Operations []FuzzingReportOperation `json:"operations"`
@@ -369,6 +375,9 @@ type ShortTestProgress struct {
 type ShortTestReport struct {
 	ApiID *externalRef0.ApiID `json:"apiID,omitempty"`
 
+	// Severity of a finding
+	HighestSeverity externalRef0.Severity `json:"highestSeverity"`
+
 	// Timestamp of the start of the test
 	Starttime int64 `json:"starttime"`
 
@@ -429,8 +438,11 @@ type TestProgressNotification struct {
 
 // TestReportNotification defines model for TestReportNotification.
 type TestReportNotification struct {
-	ApiID            *externalRef0.ApiID `json:"apiID,omitempty"`
-	NotificationType string              `json:"notificationType"`
+	ApiID *externalRef0.ApiID `json:"apiID,omitempty"`
+
+	// Severity of a finding
+	HighestSeverity  externalRef0.Severity `json:"highestSeverity"`
+	NotificationType string                `json:"notificationType"`
 
 	// Timestamp of the start of the test
 	Starttime int64 `json:"starttime"`
@@ -11148,72 +11160,72 @@ var swaggerSpec = []string{
 	"ypC5SWwGOYL2SCPF9GsdFv+1GdaU97HRTjf4UHSp2iT1ae/lih7CGDUQ/ZzXLqM7PkMxmA8yikJh+RK4",
 	"UitsY8JimWNfzlSmTK1zzr59w2Q1RWKPhSGLDe5nacoXUcvs2zeUglQ09fztklVj5tIgbhn+JaaMT5dH",
 	"CiJXw8AaUnCHEJFjckl3IvwUPuRzNeY/4YAtxG9cIQtMnhPREtU5ei7oFlakISa3p80QZXoxtUUramLQ",
-	"JiulkLRMJ9kAMLgC+fKrJi+mPOxz3nISWNRNSwGIMGUWUsYm8t0HlccAeiTUrOOGGVFG+yK3YCGI+CxT",
-	"D4DFgK0xLWgjFB2EGeeKMGucZ55frMfy3TRt5OrwEAcH29MaZUwNtbwxwVv5t10eJmo1sIvtSOBjFEO7",
-	"a9WJ1qaPYmfOtg7NUmxPpaD0roMyTOT6Zfvk53C1VQ2w1KjyrO2ucg5XQMVSuYk3fqrOZodsTIMaGwTI",
-	"f2xQoIpMKdwMVOzChLfbFRlV90gou9RJs5TtgLR2AJJQCZT05xWZSuNVJSAzhCPNh4BhiDl8GE1K/Z0p",
-	"KKxlLRGvfYUcKJ96iSg2WlCntEmJYtaFF9WpZ1PlJEFuapJepXwbj1zWauYybDAe8SXQcDodTz3fC0a3",
-	"k+n4YjqczRqRscl6KXdVT4Qk+DNK6eHy5PwDTWCDy82sS4HqwkhE6WLoPJFegPVNnG2L5FwPNcE1QWGS",
-	"pPE9hxAi8igAiR9Ewkz9Kv9vW1KaYVKdjLk+BGQZW6feFupF8aIhMtBfgGwMmMrMbNn1M4MikEO2B3PN",
-	"3FJur0MAqe9wFEmxbS7DJKmFkcbn9xkJI0vOJYQM1gk2TuDvGQL8I5BnfbIU5WmQFD7YVmgckr9tFepK",
-	"AtFBX2Jxs0yzRZyi4R+YmbZJd77dIEqt5ySv5AewwvfimA5iEEcUwLs4Y2Kq6A9uUHOrpucqRwGqu23W",
-	"DG8QZXCTWBx0QT6QNwMy6vpfUEqCa0+cA2tbnhuYFl3y5bpg9o1VfJR8bBeimbGFVxajbZt7FRgFdzuY",
-	"8vfBfBZcfJx7vjfvXY5nnu+NJ8PRYCT+15vd9ka9y/+fDbmdv5hO+vLvf4m/+ef5tNcfmj/2JsHth+t/",
-	"8T/sBJlpotVYa5O1DlOZXff73AX53mg4/208/XT7oRdcXk+5q5qPx7eXY5HFm/Sms+Gt9l0Xw9FwGvTz",
-	"pgbONnRsWK95wIgomxgRShlnmWO5Q1SIvnbcPJyABMRkFQuJlYuEmhMMBrtf2hmoPHYDXhMDE2Odkh8K",
-	"/uWteSr4bUvSyAjHxOEbZj3Fk6ucHlS0rWBgrpT+513ZPqgzQO1LowIJe7AkGAc450BOiOaAKWdzUzRr",
-	"gJval0WHYOZxKLtHHKu7XrW5Cu4E1UpAuQsfYK4hj3X/oPyObmj1E3C14xKKL/6eSqs1t2WTKW+Fu4Cr",
-	"JqHbImvGhnmxIyFi7sl0/DkYDAee702H/fFoNp9e9+fDgTUwnKsQqSyG4ixRIzt6OXExAQtIRZ5XHj8q",
-	"ZjE0QVgGfgaTk1vX12NvfO8+iwhK4R2OsMs683OluRlxzhG1ygL//SO0x5iHMCileKpOB0sW2oZhQJLM",
-	"YhP1KWEAowhg3qbY16NC42GD31MbZB23keRqJmnvm+M84K2tK24J52bbhIvOLhudcv4CrH138/+ug/4n",
-	"cQT9Q+/6ci7+N5yY1qM8steg8lpVjnoYoh4Wie24woO+DuyUEc5x+w2zdeHhX9xwRlCjNHezZryDTkql",
-	"aIHwvdpcOoB1O0LgWOTxnMOMIs318zsCTFZXcZhFiE/d4hB6k4AGpA8X64bDXPeNGbWK9dMN/RLMJmu4",
-	"9xarmPRr2V+VM7JM1chHlifbmaw2Qn6uy5DLTnkZk0WKGV40n5+Nl4DLqkGQvu5hk+s1Xq3dQX3krW1g",
-	"ovjBHcpl/GAFskEhtrnaJjhXsr0N1NYjxnVIDjJTPqegmcpbYJ121aeSJkE/gilmj4CrlmcopffLm7dv",
-	"3qptIO7xvHPvb+InYw/7TBeBEX+tkLCW+V5NEHrn3gVivbyRX6q+03A0p2hyVlycaXKiRmN9U96hqbgL",
-	"7dhO3Ft2aFuth+PQRd8IdGla3Ft0w6VSJsahU+XyuxN5jDvMzu2LWzyOXWo3uxz7VW7MOfaqXDx04U39",
-	"SlTHXp1IYrsA1qnbZadu1Zumnfp0mpi9Nkr3jrsOWipPskvXTgPXa1i4UNZ2U9WxX/f23cTSdgfTsV93",
-	"TbVcEXaxi6Vqb+4d5E2Qm8rVvL++fdvpRl5DUGrf3O9NAnnBiPI1HA+zVvgeEXnnNIVkhXywFPOQpxW4",
-	"q3oDRO8IkRVbg01GGbhDIIofUJpfUQQsBkY5jn2ORymHt9u9KXVZqmlyYk5qfrtfqKpfYpxli4VIAPjF",
-	"3Xu7FOSsPitdwRT3HrPNBqaPMroxOCU+FjHR2XfxcxA+OUVHQ9m4HiTVS1vJm2fBQN83LddTQDmgvcop",
-	"7Cvu+0jUyzKukW9niVECidvdLoycVPueGJuT4oUZDDQfAfcbIJQoNPA8rVak6sr4qRXAiftH436JoxYR",
-	"yAtKtnC5aNd1IasLFR5vbVovmnnQ9Wm1bGWXLp3CzKZaku5duweb9tqiLjzquKJIdlpGWIr6uXVsqtbn",
-	"KFG64O3LBsYyKEShyFiVw8ejxMDiKGPXELg8iT3LBryYNcW5/ROF06jFUE5iWrWU6nzk+zh8fH5Hw7nB",
-	"lVvd3a+VU3kRbydF4tnZ0hdFfsqckafBa47t7LtQ2CKgvaUPcLVC6Rs9ZRe3x/9fhLUSwD+ovIDT1R0G",
-	"4f52o0xd4dcxAbydOmnpHUdX8miTs0agJXHCEdrCmlKUsjt/ykb9xKQmJpWDwk6c4g1pJ6bMRI8jcaC7",
-	"DRsniPQSLLF+YZ2RV29M3nB0AUywYJA+qsP/j5d4wTnXxqrSMl7KZITknnWZdQPxu517ZpT143BScWpb",
-	"Xa8DM/OaUMQArCy5bUzzPXVQqxJCZOyZOfBS8UgKHwSuT+VIji/a63HJLy+JTKMEvOsokZZ7ABXYnPv3",
-	"MMKhOn0GcZSl6FDS1gtDEdaHmCn52sU+1FI+uxqJ2orqZCnaLYUlPdONh9lqhShD4VQUEu7mmCt9fyB2",
-	"lRE/RtCUsyrVONRYpGs7P52pa4QGk9xWkFMFoVfu35VReZHpl3UBFaydPMHPp+m9JIkeZXUlRQ8lMoDF",
-	"YCGXseLSYU28cpm6pnCFztaY5XUQtui4aPxRt30tp466neHZ4TiOvcC8Q89tJeJP54BO54BO54BO54B+",
-	"nHNA+wZj+zzko31Ovaj4S4RnEKyxLt3zgNkaEx5Fo0hUnROna5accvmlDHMbonSGJYR0fRfDNMxd7zaP",
-	"O9Cttet9IZd7lK1sMUH6grsumaBoA1vOIsgQZdwW0E4sujT6HU9ftOVTrD+GzkgCFqcCGjXgbBNTdk1l",
-	"XWZnOl/pTscjci/BxzRKnGzyIoy4YyCouxE3h+jZ3TKCnMC6IINc0w/MA3OVYzL0q8wA6+JiqnKBcZNB",
-	"wvZFIrk3Cd6AYJNEaIMIt4F3jwDBxVo1MitLCQ6+X0ZQLiGMkisVU9bwiuzgGR46HXBqdelsWMkZIhQz",
-	"fH8cO5mXzrNayp5gGMhL6anCJGWhO95LF0KSQVq0qIp0LnwiTyUnw8VNSZVFxGuFsS2SXjMm8n4d5UJp",
-	"qaytZO640nkg0XKuYe5qsV6V8Mj6D/LdDlFDtznz9aOwfK/8WQduv/w+SQt7fzxx62CMdJJWZGcb9uba",
-	"JbSXV5A7uudsfr7V5fm/4uJs80uWh4Dz9VfajzAi7Bp3w+soC6CfRDuieAGjv+ygI6Is4l4KMpCFFU/a",
-	"cdKOn0479DtIfH0ow9rd9eRSwZoKUK9UYUh6y1K4QNTb+pj2SRhfNJDJxVBkFg8jhiKrfRLDkxjuJIZx",
-	"cigpjJOfZdl/EiNDjMT+y9l3vOW6MBePFWLykqyLDLhFTAc3D005wdoTsbbc4CQAop3YwTKf17Qk4kT5",
-	"5qKxOGFivMcJSQg4bUG5BmZrfFOw4ux7zoEnR/1Vt0DH5vMkB2eUb4ViPqnRqvZNJ7+NsvAnRX++GNqo",
-	"02Xd6dDirdrJYluYgqvmnYsVYp/zWmkvzDaJlh7eQqjP5jyQnoZdpRvn3Epa+RjMmTICKKQJWrRuKk0R",
-	"SxG+R6b9KJ1ElRl+WQHYB+/evgOjmIEPcUZCELM1Sh8wrbPkg8DlAmmL13Qi+Afz3Qe50KNvczJR304c",
-	"PH+3BxaitqUuemkpoG8/lk5iBpaciRUxdJOHmjhK2WsQyNezx1mI5WmX87TLeaBdTiXm/J9W+eYCCCCY",
-	"w3Ql0jo28eSA8gZHF82KyUPpPV4Up6j03yzWpVttC3TVymvJgJaHEs/Pcu2XDwfb4DL5mGwHoMaTqjaA",
-	"xucOQPPHWf2GZHD+uQNQ+ea8NSksvnQAJR6uFyxrBioft+/GIP3KkI0z6luXDPU7y2MOMuJdZhEo1Ln7",
-	"Ta09HeZ7GCr3jkJQPIh0BM+ttM1w3r7395clRkDkM/HAduapat7cgwTTep6ZFa+tZlSWgZZF68thSYO/",
-	"L1VA/5kPjljqvTcuJOtqdZJmU5qbpUzLtbNEFwXVDyfPxfM2P78069LyJ1k+viwX20rqKNc+sixaq1r7",
-	"P+XZruJZlsOV5GkcSL1Qc1KTV6EmaturQUviBPxpAckCRX8GEKQZIfr5ORetiZPXozQ7R/En2SvLnqtI",
-	"uMhiCh+Wrlm3qXyxRjyvJuvM1bIfzaHItBjIe0bzVn/L00LfKXzQOac85WRPb26fasO65RVom92aVBlo",
-	"vGDrwMRJTGtcPLwjbGBgW0UAV3tSYbMrPdxXqDKEz8379/zFNofNFajfhjK3VEJEGF5imbXGjALzTdsm",
-	"ZXsdMb+/06tOFiTNKTuU9m18D+/mmQMr4z2y9h0du8WxyEAn+aP6ranGLdOMIq4TmEh6yWMA+VPPiyxN",
-	"RUVg5VYEPJND/Met+yYrxOSDV89M7MrzWhaC99VcymiXp9awv7qFDJhuy+8L5nbbT41MuTB1/08PmK05",
-	"Y6RI/Hn7Qv/nzljNldLsplXbyNxJvbIkhAzJt+zcuSze/ZNd9au5BpszEqIULOUzec08vjaGfk7danqv",
-	"b684qhMBfrS4SpXdE1J2vQ+XeYhVY/PhY6xtHH6WQOt6T85bFPHAh4Ny13XY40H29ySf9QhQiVjiwDMk",
-	"MHpURyyMo4Wm+Soq+dWpOOcwQE8BAQYEWxG6KmHnJgaqMOAkME84vroolY+pOVCclWzYwlT7wPvcudmu",
-	"UoI1UlxMKZCkrHOD6MqhjVpxQH5eIPbKmPmsx3NbjuUWomIpU9LAp63K+lrOQ9V4fjoWdToWdaBjUWWh",
-	"R5Xj7/rRoS2y382kIXUxYLuA107hu0i5wvQVpygObMBQ8RIZRem9Jk2WRt65qEjpPd08/ScAAP//Wlf6",
-	"Ll2+AAA=",
+	"JiulkLRMJ9kAMLgC+fKrJi+mPOxz3nISWNRNSwGIMGUWUq7xao1ofk5zt6Hz3uaieDdQ8lxBj4RaFril",
+	"R5TRvkhWWCgsPstcBmAxYGtMC2ILywHCjLNZ2EkuBJ5fLPDy7TltNevwEAcH2/MkJofLWBs6X6f4jTm4",
+	"VVy2i99ELT52MVUJfIxiaPfkOq/b9FFsBNqWvVmK7ZkblN510L2JXC5tn/wcrrZqHZYKXJ71wWXe7urn",
+	"cAVULJi7KOOnKnl2yCY1mCGDovmPDQagIsIKt1KqyE1e8XZLKdcJPRLKLnViLWU7IO03gCRUMisjlIrY",
+	"pvGqEmIa8pfmQ8AwxBw+jCal/s40Ffa/trWgvZ8cKJ96iSg2WlCnRFCJYtalJNXJdFOrJUFuaspUpXwb",
+	"j1xWn+bCcjAe8UXdcDodTz3fC0a3k+n4YjqczRqRsUl/KRtXT+0k+DNK6eEy//wDTWBDEJFZFzfVpZ5Y",
+	"d4ih862BAqxv4mxb9ueaqQmuCQqTJI3vOYQQkUcBSPwgUoDqV/l/2yLZDPzqZMz1ISDL2Dr1tuA1ihcN",
+	"sY7+AmRjwFSuacs+phnmgRyyPTxt5pbytR1CYtN2s9aI0CSphZHG5/cZCSNLFimEDNYJNk7g7xkC/COQ",
+	"p5eyFOWJnRQ+2NacHJK/bV3tSgLRQV/LcbNMs0WcouEfmJm2SXe+3SBKrSc/r+QHsML34uARYhBHFMC7",
+	"OGNiqugPblBzq6bnKkcBqrtt1gxvEGVwk1higIJ8IG8GZNj3v6CU1te+OQfWlnAwMC265AkIwewbq/go",
+	"+dguRGZYUhajbduVFRgFdzuY8vfBfBZcfJx7vjfvXY5nnu+NJ8PRYCT+15vd9ka9y/+fDbmdv5hO+vLv",
+	"f4m/+ef5tNcfmj/2JsHth+t/8T/sBJlpotVYa5O1DlOZXff73AX53mg4/208/XT7oRdcXk+5q5qPx7eX",
+	"Y5GXnPSms+Gt9l0Xw9FwGvTzpgbONnRsWK95TIoomxgRShlnmTW6Q1SIvnbcPJyABMRkFQuJlauUmhMM",
+	"BrtfQxqozHwDXhMDE2OhlB9z/uWtec75bUsazAjHxHEiZj2XlKucHlS0rWBgLtX+513ZPqhTTe1rswIJ",
+	"e7AkGAc450BOiOaAKWdzUzRrgJvaV16HYObB1zHHYdUegbHuetXme7hXVUsL5X98gLnKPdYdjnJkuqHV",
+	"8cDVjqs0vmB9Ki0I3VZmpgAX/ge2ZRRsglgXZ+OUQbGNI8L6yXT8ORgMB57vTYf98Wg2n17358OBNfac",
+	"qyisLOniAFYjg3o5uTEBC0hFclye2SpmMTRBWAZ+BquWG/DXY9J87z6LCErhHY6wy1L2c6W5GdTOEbXK",
+	"Av/9I7SHsYewWaWQrU4HS+rehmFAksxidvXRagCjCGDeptgMpcIGwAbXqnYVO+69yQVT0t43x3nAW1sX",
+	"9RLOzbYJF51ddofl/AVY+5bw/10H/U/i3P6H3vXlXPxvODGtR3lkr0Hltaoc9QRJPfISe5iFk34d2Ckj",
+	"nOP2G2brIoh4ccMZQY3S3M2a8Q4675WiBcL3akfuANbtCLFpkSp0DjyKTNrP7wgwWV3FYRYhPnWLQ+hN",
+	"AhqQPlysG07A3Tcm7SrWTzf0SzCbrOHe+9Ji0q9lU1rOyDJVI+VZnmxnstoI+bkuQy7HC8qYLFLM8KL5",
+	"0HG8BFxWDYL0dQ+bXPNI1h3UR97aBiaKH9yhXMYPViAbFGKbq22CcyXb20BtPZddh+QgM+XDHZqpvAXW",
+	"mV19lGsS9CPI1wWAq5ZnKKX3y5u3b96qvSfu8bxz72/iJ2Pj/0xXzhF/rZCwlvkGURB6594FYr28kV8q",
+	"WdRwnqloclbcNmpyokZjXV7Aoam4QO7YTlz2dmhbLSLk0EVfo3RpWlz2dMOlUlvHoVOlYoATeYyL387t",
+	"i6tPjl1q1+Ec+1WuGTr2qtzWdOFN/R5Zx16dSGK7Ndep22WnbtXruZ36dJqYvaBM9467Dlqq6bJL104D",
+	"1wt/uFDWdr3XsV/39t3E0nZx1bFfd0213Kt2sYulEnnuHeT1mZvKfca/vn3b6RpjQ1BqPz/QmwTyVhbl",
+	"azgeZq3wPSLyom4KyQr5YCnmIQ9EcFf1BojeESIrtgabjDJwh0AUP6A0v9cJWAyMGib7nClTDm+3y2bq",
+	"hlnT5MSc1Px2v4VWv/k5yxYLkQDwi4IFdinIWX1WurcqLotmmw1MH2V0Y3BKfCxiorPv4ucgfHKKjoay",
+	"cT1IqtcDk9f1goG+pFsuQoFyQHvVoNhX3PeRqJdlXCPfzhKjbhS3u10YOan2PTE2J8ULMxhoPgLuN0Ao",
+	"UWjgeVot49WV8VMrgBP3j8b9EkctIpBX4WzhctGu60JWV3c83tq0Xmn0oOvTaq3PLl06hZlNBTjdu3YP",
+	"Nu0FWV141HFFkey0jLBUQnTr2FTi0FGidJXglw2MZVCIQpGxKoePR4mBxWnJriFweRJ71lp4MWuKc/sn",
+	"qs1Ri6GcxLRqKdURzPdx+Pj8joZzgyu3KnhQq0HzIt5OisSzs6UvKiOVOSMPnNcc29l3obBFQHtLH+Bq",
+	"hdI3esoubo//vwhrJYB/UHlrqas7DML97UaZusKvYwJ4O3WY0zuOruTRJmeNQEvihCO0hTWlKGV3/pSN",
+	"+olJTUwqB4WdOMUb0k5MmYkeR+JAdxs2ThDpJVhi/cI6I2/3mLzh6AKYYMEgfVSH/x8v8YJzro1VpWW8",
+	"lMkIyT3rMusG4nc798wo68fhpOLUtmJoB2bmNaGIAVhZctuY5nvqoFYlhMjYM3PgpeKRFD4IXJ/KkRxf",
+	"tNfjkl9eEplGCXjXUSItVw0qsDn372GEQ3X6DOIoS9GhpK0XhiKsDzFT8rWLfailfHY1ErUV1clStFsK",
+	"S3qmGw+z1QpRhsKpqL7czTFX+v5A7CojfoygKWdVqnGosUgXxH46UzcVDSa5rSCnCkKv3L8ro/LK3C/r",
+	"AipYO3mCn0/Te0kSPcqSVIoeSmQAi8FCLmPFvcaaeOUydU3hCp2tMctrPWzRcdH4o277Wk4ddTvDs8Nx",
+	"HHtVfoee2+rqn84Bnc4Bnc4Bnc4B/TjngPYNxvZ5/Uj7nHol9pcIzyBYY12e6AGzNSY8ikaRKNUnTtcs",
+	"OeXySxnmNkTpDEsI6fouhmmYu95tHnegW2vX+0Iu9yhb2WKC9AV3XTJB0Qa2nEWQIcq4LaCdWHRp9Due",
+	"vmjLp1h/DJ2RBCxOBTRqwNkmpuyaymLWznS+0p2OR+Rego9plDjZ5EUYccdAUHcjbg7Rs7tlBDmBdc0H",
+	"uaYfmAfmKsdk6FeZAdZF01RxBOMmg4Tti0RybxK8AcEmidAGEW4D7x4Bgou1amSWsxIcfL+MoFxCGFVd",
+	"Kqas4endwTO8Djvg1OrS2bCSM0QoZvj+OHYyrzdotZQ9wTCQ1x9UtU/KQne850GEJIO0aFEV6Vz4RJ5K",
+	"ToaLm5Iqi4jXqolbJL1mTOT9OsqF0lKOXMnccaXzQKLlXPjd1WK9KuGRFSHkYyei8HBz5utHYfle+bMO",
+	"3H75fZIW9v544tbBGOkkrcjONuzNtUtoLy9Sd3TP2fzmrcubicXF2ebnPw8B5+uvtB9hRNg17obXURZA",
+	"P4l2RPECRn/ZQUdE5cW9FGQgazeetOOkHT+ddujHo/j6UIa1u+vJpYI1FaBeqcKQ9JalcIGot/UF8pMw",
+	"vmggk4uhyCweRgxFVvskhicx3EkM4+RQUhgnP8uy/yRGhhiJ/Zez73jLdWEuHivE5CVZFxlwi5gObh6a",
+	"coK1d3VtucFJAEQ7sYNlvklqScSJCtFFY3HCxHjEFJIQcNqCclXM1vimYMXZ95wDT476q26Bjs03XQ7O",
+	"KN8KpfrKyFa1bzr5bVSePyn688XQRp0u606HFm/VThbbwhRcNe9crBD7nNdKe2G2SbT08BZCfTbngfQ0",
+	"7CrdOOdW0sonbc6UEUAhTdCidVNpiliK8D0y7UfpJKrM8MuawD549/YdGMUMfIgzEoKYrVH6gGmdJR8E",
+	"LhdIW7ymE8E/mO8+yIUefZuTifp24uD5uz2wELUtddFLS41++7F0EjOw5EysiKGbPNTEUcpeg0C+nj3O",
+	"QixPu5ynXc4D7XIqMef/tMo3F0AAwRymK5HWsYknB5Q3OLpoVkweSu/xojhFpf9msS7dalugq1ZeSwa0",
+	"PJR4s5drv3xt2QaXyRd4OwA13qG1ATQ+dwCav2jrNySD888dgMqH+q1JYfGlAyjx2r9gWTNQ0aYjg/RD",
+	"RjbOqG9dMtTvLO9FyIh3mUWgUOfuN7X2dJjvYajcOwpB8ebSETy30jbDefve31+WGAGRb+sD25mnqnlz",
+	"DxJM63lmVry2mlFZBloWrS+HJQ3+vlQB/Wc+OGKp9964kKyr1UmaTWluljIt184SXRRUP5w8Fy/o/PzS",
+	"rEvLn2T5+LJcbCupo1z7yLJorWrt/5Rnu4pnWQ5XkqdxIPVCzUlNXoWaqG2vBi2JE/CnBSQLFP0ZQJBm",
+	"hOgX7ly0Jk5ej9LsHMWfZK8se64i4SKLKXxYumbdpvLFGvHgmqwzV8t+NIci02Ig7xnNW/25UAt9p/BB",
+	"55zylJM9vbl9qg3rllegbXZrUmWg8UiuAxMnMa1x8fCOsIGBbRUBXO1Jhc2u9HBfocoQPjfv3/MX2xw2",
+	"V6B+G8rcUgkRYXiJZdYaMwrMZ3OblO11xPz+Tq86WZA0p+xQ2rfxPbybZw6sjPfI2nd07BbHIgOd5I/q",
+	"t6Yat0wzirhOYCLpJY8B5K9JL7I0FRWBlVsR8EwO8R+37pusEJMPXj0zsSvPa1kI3ldzKaNdnlrD/uoW",
+	"MmC6Lb8vmNttPzUy5cLU/T89YLbmjJEi8eftC/2fO2M1V0qzm1ZtI3Mn9cqSEDIk37Jz57J490921e/o",
+	"GmzOSIhSsJTP5DXz+NoY+jl1q+m9vr3iqE4E+NHiKlV2T0jZ9T5c5iFWjc2Hj7G2cfhZAq3rPTlvUcQD",
+	"Hw7KXddhjwfZ35N81iNAJWKJA8+QwOhRHbEwjhaa5quo5Fen4pzDAD0FBBgQbEXoqoSdmxiowoCTwDzh",
+	"+OqiVD6m5kBxVrJhC1PtA+9z52a7SgnWSHExpUCSss4NoiuHNmrFAfl5gdgrY+azHs9tOZZbiIqlTEkD",
+	"n7Yq62s5D1Xj+elY1OlY1IGORZWFHlWOv+tHh7bIfjeThtTFgO0CXjuF7yLlCtNXnKI4sAFDxUtkFKX3",
+	"mjRZGnnnoiKl93Tz9J8AAAD//3DrsDCSvwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api3/notifications/openapi.gen.yaml
+++ b/api3/notifications/openapi.gen.yaml
@@ -79,6 +79,8 @@ components:
       properties:
         apiID:
           $ref: ../common/openapi.yaml#/components/schemas/ApiID
+        highestSeverity:
+          $ref: ../common/openapi.yaml#/components/schemas/Severity
         starttime:
           description: Timestamp of the start of the test
           format: int64
@@ -99,6 +101,7 @@ components:
       - starttime
       - status
       - tags
+      - highestSeverity
       title: Short Test Report
       type: object
     TestProgressNotification:

--- a/api3/notifications/restapi.gen.go
+++ b/api3/notifications/restapi.gen.go
@@ -78,6 +78,9 @@ type ShortTestProgress struct {
 type ShortTestReport struct {
 	ApiID *externalRef0.ApiID `json:"apiID,omitempty"`
 
+	// Severity of a finding
+	HighestSeverity externalRef0.Severity `json:"highestSeverity"`
+
 	// Timestamp of the start of the test
 	Starttime int64 `json:"starttime"`
 
@@ -103,8 +106,11 @@ type TestProgressNotification struct {
 
 // TestReportNotification defines model for TestReportNotification.
 type TestReportNotification struct {
-	ApiID            *externalRef0.ApiID `json:"apiID,omitempty"`
-	NotificationType string              `json:"notificationType"`
+	ApiID *externalRef0.ApiID `json:"apiID,omitempty"`
+
+	// Severity of a finding
+	HighestSeverity  externalRef0.Severity `json:"highestSeverity"`
+	NotificationType string                `json:"notificationType"`
 
 	// Timestamp of the start of the test
 	Starttime int64 `json:"starttime"`
@@ -641,23 +647,23 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8RXS2/bRhD+K4ttj4SkpEUPuilxA+iQ2Kh0C3RYkyNqAu6ju0MnsqD/XuyDD4mULac2",
-	"chPFeX7zzbfLA8+1NFqBIsfnB+7yHUgRfi7ulh8rYZH2XzThFnNBqJV/U6DLLUpUgrT1f0hhDKoyeBn8",
-	"hKpAVbpTN/7btEs1TXmml8wzvqhppy0+hufPuoDqqnhPe2V8DY7urC4tuKsKvGgfQ/0DRlu6NtCI9THj",
-	"xmoDlvZfhAQ+56r3er034E20gtstn3898N8tbF8K5jF7xu9p0J5zvwjRNY5jkGyOmWdf00ugHHjKmQTw",
-	"gpVW14bpLds2Ri2OCMEDCeSoa4WOzjxb21TtZOLLlVpNtQElDE72Qlbj2LV1+jmRn9ecC2vFnh+7P/T9",
-	"N8jJW1zcjwMXVXXFkD8IBy+bbg/JCO1g3D77KXoVCKvSSqce7rWuQATGesvgfYp0h15Z6XtRteiVoJ5A",
-	"cFDObRN+CGnGnYE8rMVPJ1w1EfyALPxbo4WCz792oU86zDowNmMDfUan3m6uwzGG8Q4CDXbAW7C+CRNV",
-	"xTq9Z30JckzWjhj8IFDFYMsGYtXxxZENW3EG8sBjDNTVTlvq68qwiZvwdA+O0Q6YSXZ+sYViWpUaVckI",
-	"HA1qFgaXNz+57cE1avaFuu56lfjKUglS/EBZSz5/N5tlXKKKT7OME1IFbUMmHS4JElQEJdhAfBKWCCUM",
-	"c65RgiMhTZM02J5VsNVWCoox//qTd4lXwThEHuY9X5G2iB4Gm14sPzjmJ8daIKLE86fGnEwGjfXCtVFe",
-	"f5i/BtmQl+r/oZyf6sdHVOUqhPlb1bIL+hmcE+VIQ+kF22rLoikrgARWLmPod2d/Wr83kMknGXa9NCue",
-	"cRLla5wFqaM467WIoVMxa1G6cHjzkXP2EkcTxKnAcaJe5ufly+KbqfpQ+YKoX7prvn0dCZ3j5uhxRrXV",
-	"QeMTjB+1BXa7uFsGQvWOkLO78gNYFwn4bjJLVwhPBz7nf0xmk/d+rwXtAnWm/SNieggbfgxXFO2CRrSH",
-	"87LwgqvdCShxrX08KyQQWBfQQZ/c5+AZV/GmLZJlRx6yNWTpI8hnGm72uTxuojs4+qCLvffJtSJQFMXJ",
-	"VE0f31ycVxf8mUvb2MdXmMHpQp8BfdpL2AxntHJRLd/PZi8q8fwoH2Rf1XkeSOqVp5ZS2H08Ax+wAEaa",
-	"LQzmiRLNxduK7wyVqSlwRrASH0B57rDlDRPO6RwFQcG+I+3a19QIcazCgX1oJlvbis/51FP0vwAAAP//",
-	"l5zmEc8OAAA=",
+	"H4sIAAAAAAAC/8RXS2/bOBD+KwR3j4Ltdhd78C1ttoAPbYK1b4UPjDSWpxAfS47cOob/+4IU9bApJ062",
+	"QW+WNc9vvvlIHXiupdEKFDk+P3CXb0GK8PPmfvGxEhZp/0UTbjAXhFr5NwW63KJEJUhb/4cUxqAqg5fB",
+	"T6gKVKU7deO/TftU05hnesk84zc1bbXFx/D8WRdQXRXvaa+Mr8DRvdWlBXdVgRftm1D/gNGWrg00Yn3M",
+	"uLHagKX9FyGBz7kavF7tDXgTreBuw+dfD/x3C5uXgnnMnvF7GrTn3C9CdI3jGCTrY+bZ1/YSKAeeciYC",
+	"fMNKq2vD9IZtWqMOR4TggQRy1LVCR2eenW2sdjLx5UqtptqAEgYneyGrcey6Ov2cyM9rzoW1Ys+P/R/6",
+	"4Rvk5C0u7seBi6q6YsgfhIOXTXeAZANtMm6f/RS9CoRVcaVjDw9aVyACY71l8D5FukevrPSDqDr0SlBP",
+	"IJiUc9eGTyHNuDOQh7V4dcJlG8EPyMK/NVoo+PxrH/qkw6wHYz020Gd06u3mmo4xjDcJlOyAt2BDEyaq",
+	"ivV6z4YS5JisHTH4QaCKZMsSser54siGrTgDOfEYA3W51ZaGupI2cRueHsAx2gIz0c4vtlBMq1KjKhmB",
+	"o6RmYXBx+8ptD66NZl+o635Qia8sliDFD5S15PN3s1nGJarmaZZxQqqga8jEwyVCgoqgBBuIT8ISoYQ0",
+	"5wolOBLStEmD7VkFG22loCbmX3/yPvEyGIfIad7zFemKGGCwHsTyg2N+cqwDopF4/tSYo0nS2CBcF+Xn",
+	"D3OL5RYcLWEHnv6vi9Z5/7JRhbxU/w8p/lQ/PqIqlyHM36qWfdDP4JwoRxqKL9hGW9aYsgJIYOUyhn4Z",
+	"96f1ewMZfaJh30urGRknUf6MwyV21JBnJZrQsZiVKF24DfCRg/sS6SPEscCUO+O7cHkFLt9H3+zgSMU1",
+	"nBuXrrNvX0dE57g+euRRbXQ4RiKMH7UFdndzvwgUG5xSZ9fxHVjXUPLdZBZvKZ4gfM7/mMwm7710CNoG",
+	"Mk2Hp9D0EETkGG5B2gUZ6s7/ReE1XbsTUBrl8PGskEBgXUAHfXKfg2dcNZd5ES17OpGtIYvfWT5Tuuvn",
+	"Crxu3MHRB10Edcq1IlDU6J+p2j6+uWZeffBn7oVj33dhBqcrfgb0aS9hV5zRyjWC/H42e1GJ57eFJPuy",
+	"zvNAUq9FtZTC7ptjdocFMNLsxmAeKdHe7a34zlCZmgJnBCtxB8pzhy1umXBO5ygICvYdadu9plaamyoc",
+	"2F072dpWfM6nnqL/BQAA//9TEzQkMg8AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/pkg/modules/internal/fuzzer/model/api.go
+++ b/backend/pkg/modules/internal/fuzzer/model/api.go
@@ -127,12 +127,6 @@ func (api *API) GetLastShortStatus() (*restapi.ShortTestReport, error) {
 				fuzzingReportTag := restapi.FuzzingReportTag{Name: tag.Name, Operations: []restapi.FuzzingReportOperation{}}
 				for _, op := range tag.MethodAndPathList {
 					logging.Logf("[Fuzzer] API(%v).StartFuzzing(): ... ... method %v %v", api.Id, op.Method, op.Path)
-					fuzzingReportTag.Operations = append(fuzzingReportTag.Operations, restapi.FuzzingReportOperation{
-						Operation: &common.MethodAndPath{
-							Method: (*common.HttpMethod)(&op.Method),
-							Path:   &op.Path,
-						},
-						RequestsCount: 0})
 				}
 				shortReport.Tags = append(shortReport.Tags, fuzzingReportTag)
 			}

--- a/backend/pkg/modules/internal/fuzzer/restapi/openapi.yaml
+++ b/backend/pkg/modules/internal/fuzzer/restapi/openapi.yaml
@@ -879,10 +879,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FuzzingReportTag'
+        highestSeverity:
+          $ref: ../../../../../../api3/common/openapi.yaml#/components/schemas/Severity        
       required:
-       - starttime
-       - status
-       - tags
+        - starttime
+        - status
+        - tags
+        - highestSeverity
             
     FuzzingReportTag:
       title: Report tag item
@@ -898,9 +901,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FuzzingReportOperation'
+        highestSeverity:
+          $ref: ../../../../../../api3/common/openapi.yaml#/components/schemas/Severity        
       required:
-       - name
-       - operations
+        - name
+        - operations
+        - highestSeverity
       
     FuzzingReportOperation:
       description: Report tag operation
@@ -919,7 +925,11 @@ components:
           type: array
           items:
             $ref: '../../../../../../api3/common/openapi.yaml#/components/schemas/APIFinding'
+        highestSeverity:
+          $ref: ../../../../../../api3/common/openapi.yaml#/components/schemas/Severity        
       required:
+        - operation
         - requestsCount
         - findings
+        - highestSeverity
            

--- a/backend/pkg/modules/internal/fuzzer/restapi/restapi.gen.go
+++ b/backend/pkg/modules/internal/fuzzer/restapi/restapi.gen.go
@@ -139,8 +139,11 @@ type FuzzingReportItem struct {
 
 // Report tag operation
 type FuzzingReportOperation struct {
-	Findings  []externalRef0.APIFinding   `json:"findings"`
-	Operation *externalRef0.MethodAndPath `json:"operation,omitempty"`
+	Findings []externalRef0.APIFinding `json:"findings"`
+
+	// Severity of a finding
+	HighestSeverity externalRef0.Severity      `json:"highestSeverity"`
+	Operation       externalRef0.MethodAndPath `json:"operation"`
 
 	// Request count to this operation item during the test
 	RequestsCount int32 `json:"requestsCount"`
@@ -157,6 +160,9 @@ type FuzzingReportPath struct {
 
 // Report tag item
 type FuzzingReportTag struct {
+	// Severity of a finding
+	HighestSeverity externalRef0.Severity `json:"highestSeverity"`
+
 	// Tag name
 	Name       string                   `json:"name"`
 	Operations []FuzzingReportOperation `json:"operations"`
@@ -219,7 +225,7 @@ type ScoreExitStatusEnum string
 
 // Describes the progress of an ongoing test
 type ShortTestProgress struct {
-	ApiID *interface{} `json:"apiID,omitempty"`
+	ApiID *externalRef0.ApiID `json:"apiID,omitempty"`
 
 	// Progress of the test
 	Progress int `json:"progress"`
@@ -230,7 +236,10 @@ type ShortTestProgress struct {
 
 // Short Test Report
 type ShortTestReport struct {
-	ApiID *interface{} `json:"apiID,omitempty"`
+	ApiID *externalRef0.ApiID `json:"apiID,omitempty"`
+
+	// Severity of a finding
+	HighestSeverity externalRef0.Severity `json:"highestSeverity"`
 
 	// Timestamp of the start of the test
 	Starttime int64 `json:"starttime"`
@@ -260,8 +269,8 @@ type Test struct {
 
 // TestHandle defines model for TestHandle.
 type TestHandle struct {
-	ApiID     *interface{} `json:"apiID,omitempty"`
-	Timestamp *int64       `json:"timestamp,omitempty"`
+	ApiID     *externalRef0.ApiID `json:"apiID,omitempty"`
+	Timestamp *int64              `json:"timestamp,omitempty"`
 }
 
 // contains all input parameters for a test
@@ -277,8 +286,8 @@ type TestInputDepthEnum string
 
 // TestProgressNotification defines model for TestProgressNotification.
 type TestProgressNotification struct {
-	ApiID            *interface{} `json:"apiID,omitempty"`
-	NotificationType string       `json:"notificationType"`
+	ApiID            *externalRef0.ApiID `json:"apiID,omitempty"`
+	NotificationType string              `json:"notificationType"`
 
 	// Progress of the test
 	Progress int `json:"progress"`
@@ -289,8 +298,11 @@ type TestProgressNotification struct {
 
 // TestReportNotification defines model for TestReportNotification.
 type TestReportNotification struct {
-	ApiID            *interface{} `json:"apiID,omitempty"`
-	NotificationType string       `json:"notificationType"`
+	ApiID *externalRef0.ApiID `json:"apiID,omitempty"`
+
+	// Severity of a finding
+	HighestSeverity  externalRef0.Severity `json:"highestSeverity"`
+	NotificationType string                `json:"notificationType"`
 
 	// Timestamp of the start of the test
 	Starttime int64 `json:"starttime"`
@@ -1177,58 +1189,59 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xc7W/bNhr/VwjefdgALcnW3n0IcB+U1EmNpbbPdjrciiBgJNrmKpEaSTlzC//vB75I",
-	"oiTKlvPSBl2BAYtN8uHz8nteyIfuZxixNGMUUyng6WcoohVOkf4zzMicfcRU/Y2SZLyApx8+w39yvICn",
-	"8B/H1bpju+g4zOWKcfIJScLoTH2Jz5DAcBt8hhlnGeaSYE37I96o/8lNhuEpFJITuoTbAK5RkmPPyDaA",
-	"HP+ZE45jePpBLy8m3wTFZHb3B44k3N5sA+hhRZGNiYg4SQlFknH1RYqyTO1Qk7dDumI8gGdIkEht0TW3",
-	"mhDAM4w45jtJu1O2QaGrzQgpro142wAyinsYodpaqX2nuQqB9k2ssdehXW3o06adjWUOQM18k+EBzdOW",
-	"yTWltq0bvJTLla2xsnWmvoanMKQA0zzFXM8DC8aBXGGA3NVAEQcZ4ijFEvMjGECsiX2AZ+FseB5ez9/C",
-	"AIaT4Xz862CkbDsIp4Op+aSYIzJR3LV4gkEb6w6Int7BMiTEPeOx18tygTlFaQ9HK2cGFUW/w9VQ/vTy",
-	"yILwbn7NND+HF4TG1tXrtGtAaeLG+QTYQmNmYQlV9n7jLPFYutB1nbLy7m6SI6P1Fi1OxMc2LfVtN62p",
-	"WhN4VFdMuKiWNN3LDom22ojEaf2PXaYutnB2Hep15Z6Ic7TR40yixKOvOyWh3iwAucCxduIMLVU0t5q3",
-	"lOeaQkmZUImXmPtEFl6Z80+fCF1Occa4VFy2mTnPOcdUgkX+6RPmgOupMNiNrJYxF45y6/SviJBK3AzJ",
-	"lQByhSRYIQHuMKZmzxgG/RQ/RfelrI78E0XYo/yOuKD8Xy14RkZrWlfs9WFXsJxHfoaFRDIX3iGJhZzb",
-	"1LTDK1ow2IeVcWbzS1tPZgKQaAlYOauJFxcPTZ0dHR03/kMZeaUUmTJ6zDJMUUaONihN/KF2MvS4YIEM",
-	"kBAhPeplrkBPw8g7LFcsDmlcmFjFbyykOGc5lT7F6WEQqWEgGZArIiod6oAA4lxZT4c/ZVsYwAXjKZLG",
-	"+V/94gbDNj2syCF/vHCzS51Tx31vXPJeO+/GjVbFA2NMhjYJQ/5Ez7HIGBW4azBPpDNUih3AnBN/fY75",
-	"3QFOo+XaJ/wcLXe6CzGeV5fan1LnaAlsuVKmAuerpjSlgQ5IY353dxRQftnhVA1MWd4cVvxgIrvjz0wH",
-	"u5DGZklbNQszD5ioCBCNLaBM3m9girMlx0L4wcHLLVAcE0UfJZPa+t4a1FF1G3TkFLNRKXpNKT5dVBG/",
-	"BwNGY96zhqVTShpUCrlpIb2p+X026nM8cU8eb8ajAQzgYDodT2EAh6PbyXR8OR3MZp3M+LDulgGtUq6y",
-	"45AumNfz95UyCYs6Ml8xAsxkIO0huvS3dnp2kz4oKfuLFZGhqCvA6XB9QIE0w2vMiTRV6N76wFWpx+rO",
-	"8FlO48RzPI6RRG2FjTP0Z46BGlQ6yyOZc1yeWDm6951AFCWP2av6qK8K9ALjFn09ahYxjgd/Een6VLH4",
-	"NsVCoKUnWr8zA2BJ1goXMZaIJAKgO5ZLLSr+SwWC0hsLWc0uwC73SS1JioVEaeZJLJX6QDkNmGrhP0rn",
-	"+Cf1tZtBSmLBntOnw2m1xFogMMa+8cLH4mM3iEpwtmAknJEmhw0alXUPCEFnw/lsePl2DgM4D6/GMxjA",
-	"8WQwejPSf4Wz23AUXv1vNlDx6XI6OTeff9ef1fB8Gp4P3C/DyfD24vp39cGvkFmhtJZpfVg7QJTZ9fm5",
-	"Cp0BHA3mv42nv95ehMOr66kKsfPx+PZqPLqEAZyE09ngtoi5l4PRYDo8L6c6PPvY8XG9UoUOFnLiZNY6",
-	"z+YO4Q4LDf0i4ag0iChgdMk0Yk1x24jeGRm+qS5vn/DMoAlvt0GtIKizPXEYdcrvFP1FUqXyn09OApgS",
-	"aj6d7LkzcaoMIRGX2hXbZV7pt3ZTPbfBgXsA+PfrevhQNRVxa8Kuir9iwl8DaLsCZVhQKqK7DihR0FWk",
-	"OeSm/mr/C9j66yj+EdVbsfTdvkSjUqitf22yCQBR/rVpZxebtYqJ3iyDlg88OKgjz7Z2Rul3WHDhWCUb",
-	"tOzCZDcU57YwqqMLc854pxrDUimEgggJfXuplzjqG7gkPEp7hkhSxtSXE0YCuM4Tijm6Iwnpcyp635ju",
-	"1plzLDpt+Bb5K8svECdqRVZbTZ6rV58AQ5rlnkgYMSoRoQKgJAFEzan6MkI7MupIhrahcmDbwRxxsv1r",
-	"S57fqNne46Ohc7NL4Gpxn0aVkV+T9Xen/ns9PP8VBvDN4CK8vprrvwYTNyjUd/Y5pludjJgkC1Id6Frd",
-	"nEeC6AwJXNtjXweyXT/plk6VS18uxzYGl/z+RuSqyv9fPP4mqGBp3i8oqgXFTQzHESZr23l5giD5FcrK",
-	"6vKqd5VR3e18+/mE0OU7FucJVqJ78ko4GYohPUfRCvsvB9eYC/8dUSNKFhODGs2uqPno/qMW+qU0H41E",
-	"HlHfV9qrC3uwWn2KfN/GUJ82cp2TiBNJIp+OtOBqucKqo5DzYoUP1yuyXPUn9VbN9pFJ2H1/Klfs3ksk",
-	"xTHxpeQuOu/MfB+pDhh1UeqBmXoTvzCqmkHsnW0jW0yG5wniRG7AJMmXhF6YNlI4GTobd8yCjiPDk6OT",
-	"o59tv0RlSXgKXx2dHL2CTlP4GFHKVMiIRYaj48+6/tyqkSX2NvUkV5nEvMEplgK11hR3VPFpD2cBeH3y",
-	"GoyYBBcspzFgcoX5PRG1vskwhqfwEsuwIDbLcKQ5LKpGXQ0QtXtm2lKmh2RLZdeLJM9x8GyV803Vl9Oq",
-	"++XkRPsVoxKbBijKssTWGcd/COP1FTd1TWqVEQrUPHuN6UeJv8UidSTaBvD1yetHcKGrkKI88dyTtvZX",
-	"1gGUSbBQJjX3DnmaIr7pjY7i6Hv6QbcYkp9MnxTeKGLKNMVl4l40huKjOVMUDV176+Y4R6qTYqD7ZuFk",
-	"eASGaZbgFFPF2N0GYBSt7CQvKituXiQmg8cSrEQ6nmEqiCRrDB8N9ad++iB8UAxNrCmfQtjLeD1vgWyL",
-	"/EuznJFp0bv3sKyLfMCrGa73XGJZAdkJpgq6FqHaQ5S77HUNlQ4AAnPE1XAT2Wq0HHqRqG4ES8zXJKp6",
-	"acVnyYryXHP9Z475pmLbzoIuo60irLmVfkqqwoh5BOyjK83D0AOIOs8xfQSd4QOIlg87/USd4QOImhfa",
-	"Pnpm5ABS+pm3Nlk3UfMU/DADFW1on2XsWDe5dmR77bnOz6MIC7HIE1B5s0q1J18y1Z6h2BYGOAZVx/wr",
-	"5HzrbU7aD+C/vqwyhlQqH0mADqGNyNkMdjvKCzd4HrvXGN4oas725sayXsG0KoXaJde3WL4eeM3ngVGX",
-	"V30HswvmbswVsO4GdHVJ9hRwrlqZf08wF5eH36H8FaCs72D1fRoTj4CynmcvTl8ojPVjtzMWb54MwVV/",
-	"brvdbv0Vz5NtZDuZ373k63gJy3Y5CcvADxGiEU5+BAjwnNLiNdJup2HZy/aZB1fw36FXh15fgHihyNH9",
-	"ou9d3dS0IPVzGXW+9tx0+OqQabUFfMac337T6VHlFN0Xt03lZZP//nO3kB3HkxfqbP7Q0jSn87p5p0kn",
-	"TLRs+vQJsMOcda1tHxxIGkbvq4kdx1JTuJdh/XP5RqdHKwYVXX63ARNjKsmCmEtuIgVwnza3vezlVvrB",
-	"g7r1HsZdBXQzv/891HMePRrvTPb3f/zhx4OI3fATxaMBL9IusQS5wMoHCDUK0j+Tqh78R/YXb0X+0PRc",
-	"k6gvu7ss5s3CM+u18ULCo9vid3t1hutCee7s9yiAiNrtvTbcYX3WxLW56+U/3BO5UjYw5v6x6yD/97uQ",
-	"mlv3eJj/7FL6bkfKsxhJbJ4f9TeyfqpllhbvnB0r5zTGHNjfAfpMfO1s+pxe1PW46lGV0kGifwuV04Sz",
-	"NYkNyK4fZnNVRLWM/vRV1C57P0spdf1IHCgPdB5cdSYzpXo7r4zR7zqz0/vywduzeVaxhceV3rt84oJN",
-	"fxbqkElTFZivC/do/GxxjTlXiLxDAut/D8KoPkmA8+vmAOY8gafwWL8OsAZokhqsMd/IlXJ7UxyUr5Ks",
-	"F1pTtas6868LCPNE727jPuG4Hlbrawbf3mz/HwAA///NaWe9B0sAAA==",
+	"H4sIAAAAAAAC/+xcX2/bOBL/KgTvHnYBbZLd9u4hwD0oqZMam9o+2+nitggCRqJtbiVSS1LJuoW/+4F/",
+	"JFESZcuJ0wbdAgtsbJLD4cxv/pAz7mcYsTRjFFMp4OlnKKIVTpH+M8zInH3EVP2NkmS8gKcfPsN/cryA",
+	"p/Afx9W6Y7voOMzlinHyCUnC6Ex9ic+QwHATfIYZZxnmkmBN+yNeq//JdYbhKRSSE7qEmwDeoyTHnpFN",
+	"ADn+Myccx/D0g15eTL4Jisns7g8cSbi52QTQw4oiGxMRcZISiiTj6osUZZnaoXbejtMV4wE8Q4JEaouu",
+	"udWEAJ5hxDHfStqdsgkKWa1HSHFtjrcJIKO4hxKqrZXYt6qrONCuiTX2OqSrFX3a1LPRzB6oma8zPKB5",
+	"2lK5ptTWdYOXcrnSNVa6ztTX8BSGFGCap5jreWDBOJArDJC7GijiIEMcpVhifgQDiDWxD/AsnA3Pw+v5",
+	"WxjAcDKcj38djJRuB+F0MDWfFHNEJoq7Fk8waGPdAdHhDSxDQjwwHnutLBeYU5T2MLRyZlBR9BtcDeWH",
+	"P48sCG/n10zzc3hBaGxNvU67BpQmbpxPgC00ZhaWUKXvN84Sj6YLWdcpK+vuJjkyUm/R4kR8bNNS33bT",
+	"mqo1gUd0xYSLaknTvOyQaIuNSJzW/9im6mILZ9ehXlfuiThHaz3OJEo88rpTJ9SbBSAXONZGnKGl8uZW",
+	"8pbyXFMoKRMq8RJz35GF98z5p0+ELqc4Y1wqLtvMnOecYyrBIv/0CXPA9VQYbEdWS5kLR7h1+ldESHXc",
+	"DMmVAHKFJFghAe4wpmbPGAb9BD9FD+VZnfNPFGGP8Dv8grJ/teAZGa1JXbHXh13Bch75GRYSyVx4hyQW",
+	"cm5D0xaraMFgF1bGmY0vbTmZCUCiJWDlrCZeXDw0ZXZ0dNz4D2XklRJkyugxyzBFGTlaozTxu9rJ0GOC",
+	"BTJAQoT0iHdFliss5AzfY07k+nDslBRVXuNK7TDk32G5YnFI4wJHKkhgIcU5y6n0aUcPg0gNA8mAXBFR",
+	"KUp7HRDnCiLaxyoAwQAuGE+RNB7m1S+ux23Tw4oc8jslN4S56Khz7fiLtmZu3M29UNsOXS2oR7q5DK0T",
+	"hvy5BsciY1TgrsE8kc5QKZQA5pz4rwiY3+1ht/pcuw4/R8utFkuM8ddP/UVsw586zNES2LSsDHnOV02R",
+	"lSjYI1z73Zoj5fLLDufRgLXlzWGlL4bJds87024+pLFZ0hbWwswDJh4ARGOLY5PxNKDM2ZJjIfyY5OUW",
+	"KI6Joo+SSW19b5nqeLIJOqKp2ag8ek0oPllUsa4HA0Zi3luWpVOeNKgEctMysKbkd+moz8XMvXO9GY8G",
+	"MICD6XQ8hQEcjm4n0/HldDCbdTLjQ7+bALWS2EqPQ7pgXoezK4lLWNQR84sRYCYDaZ8PSgtsJyZuugNK",
+	"yv40TWQo6vKrOm7skRq6PkfuzIxckXq07gyf5TROPA8DMZKoLbBxhv7MMVCDSmZ5JHOOy7s6Rw++u5ei",
+	"5FF7lRn2FYFeYMyir0XNIsbx4C8iXZsqFt+mWAi09Pjvd2YALMm9wkWMJSKJAOiO5VIfFf+lHEFpjcVZ",
+	"zS7ALvedWpIUC4nSzBPPKvGBchowKcx/lMzxT+prN6aUxIId926H02qJ1UBglH3jhY/Fx3YQuSG2DiPh",
+	"jDQ5bNCotLuHCzobzmfDy7dzGMB5eDWewQCOJ4PRm5H+K5zdhqPw6n+zgfJPl9PJufn8u/6shufT8Hzg",
+	"fhlOhrcX17+rD36BzAqhtVTrw9oeR5ldn58r1xnA0WD+23j66+1FOLy6nioXOx+Pb6/Go0sYwEk4nQ1u",
+	"C597ORgNpsPzcqrDs48dH9crlV9hISdOZK3zbF5P7rDQ0C8CjgqDiAJGl0wj1mTcDe+dkeGbA96RNLlN",
+	"UMsC6rxOHO6ci0CK/iKpkvPPJycBTAk1n052PBE5qYWQiEttf+1srzRWu6me2+DAvYr8+3XdZ6hEirip",
+	"Ydfdo2LCH/i1MoHSJigF0R38S9V3ZWYOuan/ZvFcCv4iufvXUekTksFi6btdcUtFZJtO29gVAKLMdd0O",
+	"VjYIFhO9QQstH3kzURe3Te0S1O824gK9il1o183aB9gW7Oc286ojGXPOeKdgw1JMhIIICf0wrJc4Ah24",
+	"JDxifAavVTrtl+OyAnifJxRzdEcS0ufa9b4x3U1k51h06vAt8qeuz+WTaqlbWzaep2wf10Oa5R5XGzEq",
+	"EaECoCQBRM2p6lxC2zPqCLG2QLVnGcdcnLLda0ue36jZ3kupoXOz7cDV4j6FP3N+TdZf7fvv9fD8VxjA",
+	"N4OL8Ppqrv8aTFxPUN/ZZ41uzjNikixIdU1sVceeiKEzJHBtj10V3XZWpktkVbB+uRxbx1vy+xuRqyrB",
+	"+OJON0EFS/N+nlAtKN53OI4wubeVrAN4xq+Qt1ZPYr2TjerF6NsPIoQu37E4T7A6uieYhJOhGNJzFK2w",
+	"/8nxHnPhf3lqeMliYlCj2eU1n1zP1Yd+KcVccyLPUd9X0qsfdm+x+gT5vo2hPmX5OicRJ5JEPhnpg6vl",
+	"CquOQM6LFT5cq+y1P6m3araPTMIe+lO5Yg9eIimOiS8kd9F5Z+b7SHXAqItSD8zUmyIKpaoZxL4EN6LF",
+	"ZHieIHUjAJMkXxJ6YWpi4WTobNwxCzqGDE+OTo5+tnUZFSXhKXx1dHL0CjpF9mNEKVMuIxYZjo4/66Rz",
+	"o0aW2Fu/lFxFEtPTVCwFaq1J7qji097RAvD65DUYMQkuWE5jwOQK8wciavWZYQxP4SWWYUFsluFIc1hk",
+	"jTobIGr3zNTYTK3K5seuFUme48C2Fh48cd7cVEVGLbpfTk60XTEqsan1oixLbJ5x/IcwVl9xU5ekFhmh",
+	"QM2zj6N+lPgLN1J7ok0AX5+8fgIXOgsp0hPP62trf6UdQJkEC6VSDXSRpyni697oKG7Apx904SL5yRR9",
+	"4Y0iplRTPFHuRGMoPpo7RVGvtm95jnGkOigGuhoXToZHYJhmCU4xVYzdrQFG0cpO8qKy4uZFYjJ4KsHq",
+	"SMczTAWR5B7DJ0P90K0kwgfF0PiasrXEPvHreQtk6/1fmuWMTItGBA/LOskHvJrhWs8llhWQHWeqoGsR",
+	"qi1EmctO01DhACAwR1wNN5GtRsuhF4nqhrPE/J5EVYWu+CxZkZ5rrv/MMV9XbNtZ0GW0lYQ1t9KtucqN",
+	"mKZqH11pGm33IOq0t/oIOsN7EC0bZf1EneE9iJqOdx89M7IHKd02r1XWTdS01u+noKK47dOMHesm1/Zs",
+	"rz31gjyKsBCLPAGVNatQe/IlQ+0Zim1igGNQ1eG/Qsy31uaE/QD+68sKY0ilspEEaBfa8JxNZ7clvXCd",
+	"57H7jOH1ouZub14s6xlMK1OoPXJ9i+nrns98Hhh1WdV3MLtg7sZcAetuQFePZIeAc1Ur/XuCuXg8/A7l",
+	"rwBl/Qar39OYeAKU9Tz7cPpCYaxb6M5YvD4Ygqv63Gaz2TyjqTjly+9W8nWshGXbjIRl4IcI0QgnPwIE",
+	"eE5p0eO03WhY9rJt5tEZ/Hfo1aHXFyBeKHL0sOj7Vjc1JUjdNaPu156XDl8eMq22gM/oyNqdoh5RTtFD",
+	"8dpUPjb53z+3H7LjevJCjc3vWprqdHqmt6p0wkRLp4cPgB3qrEtt82hH0lB6X0lsuZaaxL1065/LHp0e",
+	"pRhUVPndAkyMqSQLYh65iRTAbZhuW9nLzfSDR1XrPYy7Auhmfnc/1M0z51NOn8nu+o/f/XgQsR1+omga",
+	"8CLtEkuQC6xsgFAjIP1zrOpnBJH9+V4RPzQ9VyXqy+4qi+lZeGa5NjokPLItfoRYZ7h+KM+b/Q4BEFF7",
+	"vdeK26/Omrg6d638hwciV0oHRt0/dl3k/34PUnNrHo+zn21C325IeRYjiU37UX8l61Yts7Rod3a0nNMY",
+	"c2B/XehT8bWz6XNaUVdz1ZMypb2O/i1kThPO7klsQHb9OJ2rJKql9MNnUdv0/Syp1PUTcaAs0Gm46gxm",
+	"SvR2Xumj33VGp/dlw9uzWVaxhceU3rt84oJNfxTqOJOmKjC/L8yj8WPIe8y5QuQdElj/+xpG9EkCar+i",
+	"znkCT+Gx7g6wCmiSGtxjvpYrZfYmOSi7kqwVWlW1szrzDykI06J3t3ZbOK6H1fqawjc3m/8HAAD//1eU",
+	"6qRXTAAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
feat: for Fuzzer module, adding "highestSeverity" item on Fuzzer report on
- test level
- tag level
- operation level
One minor update on api.go, just to make it compile. Everything must come with PR https://github.com/openclarity/apiclarity/pull/145