### PR TITLE
Fuzzer: Use POD_NAMESPACE or FUZZER_JOB_NAMESPACE

### DIFF
--- a/backend/pkg/modules/internal/fuzzer/clients/kubernetes.go
+++ b/backend/pkg/modules/internal/fuzzer/clients/kubernetes.go
@@ -65,7 +65,6 @@ const (
 	restlerRootPathEnvVar   = "RESTLER_ROOT_PATH"
 	restlerTimeBudgetEnvVar = "RESTLER_TIME_BUDGET"
 	authInjectorPathEnvVar  = "RESTLER_TOKEN_INJECTOR_PATH"
-	JobNamespace            = "apiclarity"
 )
 
 type K8sClient struct {
@@ -266,7 +265,7 @@ func NewKubernetesClient(config *config.Config, accessor core.BackendAccessor) (
 	client := &K8sClient{
 		hClient:                accessor.K8SClient(),
 		imageName:              config.GetImageName(),
-		namespace:              JobNamespace,
+		namespace:              config.GetJobNamespace(),
 		platformType:           config.GetPlatformType(),
 		platformHostFromFuzzer: config.GetPlatformHostFromFuzzer(),
 		subFuzzer:              config.GetSubFuzzerList(),

--- a/charts/apiclarity/templates/deployment.yaml
+++ b/charts/apiclarity/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
             - --log-level
             - {{ .Values.apiclarity.logLevel }}
           env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # space separated list of response headers to ignore when reconstructing the spec
             - name: RESPONSE_HEADERS_TO_IGNORE
               valueFrom:


### PR DESCRIPTION
FUZZER_JOB_NAMESPACE environment variable takes priority over
POD_NAMESPACE.
POD_NAMESPACE defaults to 'apiclarity' if not set.