### PR TITLE
Fuzzer: Adds delete verb to cluster role

### DIFF
--- a/charts/apiclarity/templates/clusterrole.yaml
+++ b/charts/apiclarity/templates/clusterrole.yaml
@@ -14,5 +14,5 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: [ "batch" ]
   resources: [ "jobs" ]
-  verbs: [ "create" ]
+  verbs: [ "create", "delete" ]
 {{- end -}}


### PR DESCRIPTION
The Fuzzer module needs it to delete the job.