### PR TITLE
Updated licensei version and fix caches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DOCKER_TAG ?= ${VERSION}
 
 # Dependency versions
 GOLANGCI_VERSION = 1.42.0
-LICENSEI_VERSION = 0.3.1
+LICENSEI_VERSION = 0.6.1
 
 # HELP
 # This will output the help for each task
@@ -29,7 +29,7 @@ help: ## This help.
 ui: ## Build UI
 	@(echo "Building UI ..." )
 	@(cd ui; npm i ; npm run build; )
-	@ls -l ui/build  
+	@ls -l ui/build
 
 .PHONY: backend
 backend: ## Build Backend
@@ -96,11 +96,11 @@ test: ## Run Unit Tests
 clean: clean-ui clean-backend ## Clean all build artifacts
 
 .PHONY: clean-ui
-clean-ui: 
+clean-ui:
 	@(rm -rf ui/build ; echo "UI cleanup done" )
 
 .PHONY: clean-backend
-clean-backend: 
+clean-backend:
 	@(rm -rf bin ; echo "Backend cleanup done" )
 
 bin/golangci-lint: bin/golangci-lint-${GOLANGCI_VERSION}
@@ -142,7 +142,10 @@ license-check: bin/licensei ## Run license check
 
 .PHONY: license-cache
 license-cache: bin/licensei ## Generate license cache
-	bin/licensei cache
+	cd backend && ../bin/licensei cache --config=../.licensei.toml
+	cd plugins/gateway/kong && ../../../bin/licensei cache --config=../../../.licensei.toml
+	cd plugins/gateway/tyk/v3.2.2 && ../../../../bin/licensei cache --config=../../../../.licensei.toml
+	cd plugins/taper && ../../bin/licensei cache --config=../../.licensei.toml
 
 .PHONY: check
 check: lint test ## Run tests and linters

--- a/backend/.licensei.cache
+++ b/backend/.licensei.cache
@@ -2,6 +2,13 @@
 [[dependencies]]
   confidence = 1.0
   license = "MIT"
+  name = "github.com/getkin/kin-openapi"
+  revision = "v0.97.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
   name = "github.com/josharian/intern"
   revision = "v1.0.0"
   type = "gomod"
@@ -10,7 +17,7 @@
   confidence = 1.0
   license = "MIT"
   name = "github.com/mailru/easyjson"
-  revision = "v0.7.7"
+  revision = "v0.7.6"
   type = "gomod"
 
 [[dependencies]]
@@ -24,7 +31,7 @@
   confidence = 1.0
   license = "Apache-2.0"
   name = "github.com/go-openapi/swag"
-  revision = "v0.21.1"
+  revision = "v0.19.15"
   type = "gomod"
 
 [[dependencies]]
@@ -36,44 +43,16 @@
 
 [[dependencies]]
   confidence = 1.0
-  license = "BSD-3-Clause"
-  name = "github.com/PuerkitoBio/urlesc"
-  revision = "v0.0.0-20170810143723-de5bf2ad4578"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "BSD-3-Clause"
-  name = "golang.org/x/text"
-  revision = "v0.3.7"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "BSD-3-Clause"
-  name = "golang.org/x/net"
-  revision = "v0.0.0-20220513224357-95641704303c"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "BSD-3-Clause"
-  name = "github.com/PuerkitoBio/purell"
-  revision = "v1.1.1"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
   license = "Apache-2.0"
-  name = "github.com/go-openapi/jsonreference"
-  revision = "v0.19.6"
+  name = "gopkg.in/yaml.v3"
+  revision = "v3.0.1"
   type = "gomod"
 
 [[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/go-openapi/spec"
-  revision = "v0.20.4"
+  confidence = 0.0
+  license = ""
+  name = "github.com/invopop/yaml"
+  revision = "v0.1.0"
   type = "gomod"
 
 [[dependencies]]
@@ -141,6 +120,48 @@
 
 [[dependencies]]
   confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/urlesc"
+  revision = "v0.0.0-20170810143723-de5bf2ad4578"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/text"
+  revision = "v0.3.7"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/net"
+  revision = "v0.0.0-20211209124913-491a49abca63"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/purell"
+  revision = "v1.1.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonreference"
+  revision = "v0.19.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/spec"
+  revision = "v0.20.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
   license = "Apache-2.0"
   name = "github.com/go-openapi/loads"
   revision = "v0.21.0"
@@ -185,7 +206,7 @@
   confidence = 1.0
   license = "Apache-2.0"
   name = "github.com/openclarity/speculator"
-  revision = "v0.0.5"
+  revision = "v0.2.0"
   type = "gomod"
 
 [[dependencies]]
@@ -199,7 +220,7 @@
   confidence = 1.0
   license = "BSD-3-Clause"
   name = "golang.org/x/sys"
-  revision = "v0.0.0-20220513210249-45d2b4557a2a"
+  revision = "v0.0.0-20211103235746-7861aae1554b"
   type = "gomod"
 
 [[dependencies]]
@@ -262,7 +283,7 @@
   confidence = 1.0
   license = "BSD-3-Clause"
   name = "github.com/google/go-cmp"
-  revision = "v0.5.6"
+  revision = "v0.5.5"
   type = "gomod"
 
 [[dependencies]]
@@ -409,7 +430,7 @@
   confidence = 1.0
   license = "BSD-3-Clause"
   name = "golang.org/x/crypto"
-  revision = "v0.0.0-20220513210258-46612604a0f9"
+  revision = "v0.0.0-20210921155107-089bfa567519"
   type = "gomod"
 
 [[dependencies]]
@@ -493,14 +514,14 @@
   confidence = 1.0
   license = "Apache-2.0"
   name = "github.com/google/gofuzz"
-  revision = "v1.2.0"
+  revision = "v1.1.0"
   type = "gomod"
 
 [[dependencies]]
   confidence = 1.0
   license = "Apache-2.0"
   name = "github.com/go-logr/logr"
-  revision = "v1.2.2"
+  revision = "v1.2.0"
   type = "gomod"
 
 [[dependencies]]
@@ -556,7 +577,7 @@
   confidence = 0.0
   license = ""
   name = "google.golang.org/protobuf"
-  revision = "v1.28.0"
+  revision = "v1.27.1"
   type = "gomod"
 
 [[dependencies]]
@@ -571,13 +592,6 @@
   license = "Apache-2.0"
   name = "github.com/googleapis/gnostic"
   revision = "v0.5.5"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "gopkg.in/yaml.v3"
-  revision = "v3.0.1"
   type = "gomod"
 
 [[dependencies]]
@@ -605,7 +619,7 @@
   confidence = 1.0
   license = "BSD-3-Clause"
   name = "golang.org/x/term"
-  revision = "v0.0.0-20210927222741-03fcf44c2211"
+  revision = "v0.0.0-20210615171337-6886f2dfbf5b"
   type = "gomod"
 
 [[dependencies]]
@@ -619,7 +633,7 @@
   confidence = 1.0
   license = "BSD-3-Clause"
   name = "golang.org/x/time"
-  revision = "v0.0.0-20220411224347-583f2d630306"
+  revision = "v0.0.0-20210723032227-1f47c861a9ac"
   type = "gomod"
 
 [[dependencies]]
@@ -640,49 +654,7 @@
   confidence = 1.0
   license = "BSD-3-Clause"
   name = "github.com/imdario/mergo"
-  revision = "v0.3.12"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "BSD-3-Clause"
-  name = "github.com/google/uuid"
-  revision = "v1.3.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/deepmap/oapi-codegen"
-  revision = "v1.11.1-0.20220609223533-7da811e1cf30"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "MIT"
-  name = "github.com/getkin/kin-openapi"
-  revision = "v0.97.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 0.0
-  license = ""
-  name = "github.com/invopop/yaml"
-  revision = "v0.1.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "MIT"
-  name = "github.com/go-chi/chi/v5"
-  revision = "v5.0.7"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/openclarity/apiclarity/api3"
-  revision = "v0.0.0"
+  revision = "v0.3.5"
   type = "gomod"
 
 [[dependencies]]
@@ -695,99 +667,15 @@
 [[dependencies]]
   confidence = 1.0
   license = "Apache-2.0"
-  name = "github.com/Portshift/go-utils"
-  revision = "v0.0.0-20220421083203-89265d8a6487"
+  name = "github.com/deepmap/oapi-codegen"
+  revision = "v1.9.1"
   type = "gomod"
 
 [[dependencies]]
   confidence = 1.0
-  license = "Apache-2.0"
-  name = "google.golang.org/grpc"
-  revision = "v1.43.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "google.golang.org/genproto"
-  revision = "v0.0.0-20211208223120-3a66f561d7aa"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/openclarity/trace-sampling-manager/api"
-  revision = "v0.0.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/openclarity/trace-sampling-manager/manager"
-  revision = "v0.0.0-20220701140339-4cc0ec209fea"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/docker/go-units"
-  revision = "v0.4.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "BSD-3-Clause"
-  name = "github.com/jessevdk/go-flags"
-  revision = "v1.5.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/docker/docker"
-  revision = "v20.10.14+incompatible"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/docker/go-connections"
-  revision = "v0.4.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 0.8835616
-  license = "Apache-2.0"
-  name = "github.com/opencontainers/go-digest"
-  revision = "v1.0.0"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/opencontainers/image-spec"
-  revision = "v1.0.2"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/containerd/containerd"
-  revision = "v1.6.2"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "Apache-2.0"
-  name = "github.com/docker/distribution"
-  revision = "v2.8.1+incompatible"
-  type = "gomod"
-
-[[dependencies]]
-  confidence = 1.0
-  license = "BSD-3-Clause"
-  name = "github.com/gorilla/mux"
-  revision = "v1.8.0"
+  license = "MIT"
+  name = "github.com/go-chi/chi/v5"
+  revision = "v5.0.0"
   type = "gomod"
 
 [[dependencies]]
@@ -806,9 +694,58 @@
 
 [[dependencies]]
   confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/docker/go-units"
+  revision = "v0.4.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/jessevdk/go-flags"
+  revision = "v1.5.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
   license = "MIT"
   name = "github.com/rs/cors"
-  revision = "v1.8.0"
+  revision = "v1.8.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/Portshift/go-utils"
+  revision = "v0.0.0-20220421083203-89265d8a6487"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "google.golang.org/grpc"
+  revision = "v1.42.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "google.golang.org/genproto"
+  revision = "v0.0.0-20210602131652-f16073e35f0c"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/trace-sampling-manager/api"
+  revision = "v0.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/trace-sampling-manager/manager"
+  revision = "v0.0.0-20220503091058-2730f5ebad2c"
   type = "gomod"
 
 [[dependencies]]

--- a/plugins/gateway/kong/.licensei.cache
+++ b/plugins/gateway/kong/.licensei.cache
@@ -1,0 +1,217 @@
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/Kong/go-pdk"
+  revision = "v0.6.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/ugorji/go/codec"
+  revision = "v1.2.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/asaskevich/govalidator"
+  revision = "v0.0.0-20200907205600-7a23bdc65eef"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/errors"
+  revision = "v0.20.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mitchellh/mapstructure"
+  revision = "v1.4.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/oklog/ulid"
+  revision = "v1.3.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "go.mongodb.org/mongo-driver"
+  revision = "v1.7.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/go-stack/stack"
+  revision = "v1.8.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/strfmt"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/josharian/intern"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mailru/easyjson"
+  revision = "v0.7.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "gopkg.in/yaml.v2"
+  revision = "v2.4.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/swag"
+  revision = "v0.19.15"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/runtime"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/analysis"
+  revision = "v0.20.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonpointer"
+  revision = "v0.19.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/urlesc"
+  revision = "v0.0.0-20170810143723-de5bf2ad4578"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/text"
+  revision = "v0.3.7"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/net"
+  revision = "v0.0.0-20211101193420-4a448f8816b3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/purell"
+  revision = "v1.1.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonreference"
+  revision = "v0.19.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/spec"
+  revision = "v0.20.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/loads"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/validate"
+  revision = "v0.20.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/opentracing/opentracing-go"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/apiclarity/plugins/api"
+  revision = "v0.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/trace-sampling-manager/api"
+  revision = "v0.0.0-20220503091058-2730f5ebad2c"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/satori/go.uuid"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/sys"
+  revision = "v0.0.0-20210423082822-04245dca01da"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/sirupsen/logrus"
+  revision = "v1.4.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/apiclarity/plugins/common"
+  revision = "v0.0.0"
+  type = "gomod"

--- a/plugins/gateway/tyk/v3.2.2/.licensei.cache
+++ b/plugins/gateway/tyk/v3.2.2/.licensei.cache
@@ -1,0 +1,595 @@
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/xeipuuv/gojsonpointer"
+  revision = "v0.0.0-20190905194746-02993c407bfb"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/xeipuuv/gojsonreference"
+  revision = "v0.0.0-20180127040603-bd5ef7bd5415"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/TykTechnologies/gojsonschema"
+  revision = "v0.0.0-20170222154038-dcb3e4bb7990"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/sys"
+  revision = "v0.0.0-20210615035016-665e8c7367d1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/sirupsen/logrus"
+  revision = "v1.4.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mattn/go-isatty"
+  revision = "v0.0.12"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mattn/go-colorable"
+  revision = "v0.1.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mgutz/ansi"
+  revision = "v0.0.0-20170206155736-9520e82c474b"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/term"
+  revision = "v0.0.0-20201126162022-7de9c90e9dd1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/crypto"
+  revision = "v0.0.0-20210616213533-5ff15b29337e"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/x-cray/logrus-prefixed-formatter"
+  revision = "v0.5.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.9247449
+  license = "MPL-2.0"
+  name = "github.com/TykTechnologies/tyk"
+  revision = "v1.9.2-0.20211119141645-a642669fba58"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/pmylund/go-cache"
+  revision = "v2.1.0+incompatible"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/clbanning/mxj"
+  revision = "v1.8.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/buger/jsonparser"
+  revision = "v1.1.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/cespare/xxhash/v2"
+  revision = "v2.1.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "EPL-2.0"
+  name = "github.com/eclipse/paho.mqtt.golang"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/net"
+  revision = "v0.0.0-20211101193420-4a448f8816b3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "go.uber.org/atomic"
+  revision = "v1.9.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "go.uber.org/multierr"
+  revision = "v1.6.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "go.uber.org/zap"
+  revision = "v1.18.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/jensneuse/abstractlogger"
+  revision = "v0.0.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/jensneuse/graphql-go-tools"
+  revision = "v1.20.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/tidwall/match"
+  revision = "v1.1.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/tidwall/pretty"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/tidwall/gjson"
+  revision = "v1.11.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/tidwall/sjson"
+  revision = "v1.0.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/Masterminds/goutils"
+  revision = "v1.1.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/Masterminds/semver"
+  revision = "v1.5.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/google/uuid"
+  revision = "v1.1.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/huandu/xstrings"
+  revision = "v1.3.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/imdario/mergo"
+  revision = "v0.3.9"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mitchellh/reflectwalk"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mitchellh/copystructure"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/Masterminds/sprig"
+  revision = "v2.22.0+incompatible"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/jensneuse/pipeline"
+  revision = "v0.0.0-20200117120358-9fb4de085cd6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/nats-io/nats.go"
+  revision = "v1.11.1-0.20210623165838-4b75fc59ae30"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/nats-io/nkeys"
+  revision = "v0.3.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/nats-io/nuid"
+  revision = "v1.0.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/lonelycode/go-uuid"
+  revision = "v0.0.0-20141202165402-ed3ca8a15a93"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/lonelycode/osin"
+  revision = "v0.0.0-20160423095202-da239c9dacb6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.97849464
+  license = "BSD-2-Clause"
+  name = "gopkg.in/mgo.v2"
+  revision = "v2.0.0-20190816093944-a6b53ec6cb22"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "gorm.io/gorm"
+  revision = "v1.21.11"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/jinzhu/inflection"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/jinzhu/now"
+  revision = "v1.1.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/TykTechnologies/murmur3"
+  revision = "v0.0.0-20180602122059-1915e687e465"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/kelseyhightower/envconfig"
+  revision = "v1.4.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/opentracing/opentracing-go"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-2-Clause"
+  name = "github.com/pkg/errors"
+  revision = "v0.9.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/uber/jaeger-client-go"
+  revision = "v2.19.0+incompatible"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/uber/jaeger-lib"
+  revision = "v2.2.0+incompatible"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "gopkg.in/yaml.v3"
+  revision = "v3.0.0-20210107192922-496545a6307b"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/dgryski/go-rendezvous"
+  revision = "v0.0.0-20200823014737-9f7001d12a5f"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-2-Clause"
+  name = "github.com/go-redis/redis/v8"
+  revision = "v8.3.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "go.opentelemetry.io/otel"
+  revision = "v0.13.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/satori/go.uuid"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MPL-2.0"
+  name = "github.com/hashicorp/golang-lru"
+  revision = "v0.5.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/jensneuse/byte-template"
+  revision = "v0.0.0-20200214152254-4f3cf06e5c68"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/xerrors"
+  revision = "v0.0.0-20200804184101-5ec99f83aff1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.9878049
+  license = "MIT"
+  name = "github.com/klauspost/compress"
+  revision = "v1.13.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "nhooyr.io/websocket"
+  revision = "v1.8.7"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/asaskevich/govalidator"
+  revision = "v0.0.0-20200907205600-7a23bdc65eef"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/errors"
+  revision = "v0.20.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mitchellh/mapstructure"
+  revision = "v1.4.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/oklog/ulid"
+  revision = "v1.3.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "go.mongodb.org/mongo-driver"
+  revision = "v1.7.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/go-stack/stack"
+  revision = "v1.8.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/strfmt"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/josharian/intern"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mailru/easyjson"
+  revision = "v0.7.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "gopkg.in/yaml.v2"
+  revision = "v2.4.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/swag"
+  revision = "v0.19.15"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/runtime"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/analysis"
+  revision = "v0.20.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonpointer"
+  revision = "v0.19.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/urlesc"
+  revision = "v0.0.0-20170810143723-de5bf2ad4578"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/text"
+  revision = "v0.3.7"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/purell"
+  revision = "v1.1.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonreference"
+  revision = "v0.19.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/spec"
+  revision = "v0.20.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/loads"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/validate"
+  revision = "v0.20.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/apiclarity/plugins/api"
+  revision = "v0.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/trace-sampling-manager/api"
+  revision = "v0.0.0-20220503091058-2730f5ebad2c"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/apiclarity/plugins/common"
+  revision = "v0.0.0"
+  type = "gomod"

--- a/plugins/otel-collector/apiclarityexporter/.licensei.cache
+++ b/plugins/otel-collector/apiclarityexporter/.licensei.cache
@@ -1,0 +1,378 @@
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/errors"
+  revision = "v0.20.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/asaskevich/govalidator"
+  revision = "v0.0.0-20210307081110-f21760c49a8d"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mitchellh/mapstructure"
+  revision = "v1.5.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/oklog/ulid"
+  revision = "v1.3.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "go.mongodb.org/mongo-driver"
+  revision = "v1.8.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/go-stack/stack"
+  revision = "v1.8.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/strfmt"
+  revision = "v0.21.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/josharian/intern"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mailru/easyjson"
+  revision = "v0.7.7"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "gopkg.in/yaml.v2"
+  revision = "v2.4.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/swag"
+  revision = "v0.21.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/runtime"
+  revision = "v0.24.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/analysis"
+  revision = "v0.21.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonpointer"
+  revision = "v0.19.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/urlesc"
+  revision = "v0.0.0-20170810143723-de5bf2ad4578"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/text"
+  revision = "v0.3.7"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/net"
+  revision = "v0.0.0-20220225172249-27dd8689420f"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/purell"
+  revision = "v1.1.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonreference"
+  revision = "v0.19.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/spec"
+  revision = "v0.20.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/loads"
+  revision = "v0.21.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/validate"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/opentracing/opentracing-go"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/gofrs/uuid"
+  revision = "v4.0.0+incompatible"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/apiclarity/plugins/api"
+  revision = "v0.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mitchellh/reflectwalk"
+  revision = "v1.0.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mitchellh/copystructure"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/knadh/koanf"
+  revision = "v1.4.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "go.uber.org/atomic"
+  revision = "v1.10.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "go.uber.org/multierr"
+  revision = "v1.8.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "go.opentelemetry.io/collector"
+  revision = "v0.61.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "go.uber.org/zap"
+  revision = "v1.23.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/gogo/protobuf"
+  revision = "v1.3.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "go.opentelemetry.io/collector/pdata"
+  revision = "v0.61.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "google.golang.org/grpc"
+  revision = "v1.49.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/sys"
+  revision = "v0.0.0-20220808155132-1c4a2a72c664"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "google.golang.org/protobuf"
+  revision = "v1.28.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/golang/protobuf"
+  revision = "v1.5.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "google.golang.org/genproto"
+  revision = "v0.0.0-20211208223120-3a66f561d7aa"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/modern-go/concurrent"
+  revision = "v0.0.0-20180306012644-bacd9c7ef1dd"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/modern-go/reflect2"
+  revision = "v1.0.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/json-iterator/go"
+  revision = "v1.1.12"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "go.opentelemetry.io/otel"
+  revision = "v1.10.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "go.opentelemetry.io/otel/metric"
+  revision = "v0.32.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "go.opentelemetry.io/otel/trace"
+  revision = "v1.10.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/golang/snappy"
+  revision = "v0.0.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.9878049
+  license = "MIT"
+  name = "github.com/klauspost/compress"
+  revision = "v1.15.10"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/rs/cors"
+  revision = "v1.8.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/felixge/httpsnoop"
+  revision = "v1.0.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-logr/logr"
+  revision = "v1.2.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-logr/stdr"
+  revision = "v1.2.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+  revision = "v0.36.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/cenkalti/backoff/v4"
+  revision = "v4.1.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "go.opencensus.io"
+  revision = "v0.23.0"
+  type = "gomod"

--- a/plugins/taper/.licensei.cache
+++ b/plugins/taper/.licensei.cache
@@ -1,0 +1,539 @@
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/sys"
+  revision = "v0.0.0-20211025201205-69cdffdb9359"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/sirupsen/logrus"
+  revision = "v1.8.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/shurcooL/sanitized_anchor_name"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/russross/blackfriday/v2"
+  revision = "v2.0.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/cpuguy83/go-md2man/v2"
+  revision = "v2.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/urfave/cli"
+  revision = "v1.22.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "google.golang.org/grpc"
+  revision = "v1.42.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/Portshift/go-utils"
+  revision = "v0.0.0-20211213074910-dd69e9ff3e27"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/op/go-logging"
+  revision = "v0.0.0-20160315200505-970db520ece7"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/errors"
+  revision = "v0.20.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/asaskevich/govalidator"
+  revision = "v0.0.0-20200907205600-7a23bdc65eef"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mitchellh/mapstructure"
+  revision = "v1.4.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/oklog/ulid"
+  revision = "v1.3.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "go.mongodb.org/mongo-driver"
+  revision = "v1.7.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/go-stack/stack"
+  revision = "v1.8.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/strfmt"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/josharian/intern"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/mailru/easyjson"
+  revision = "v0.7.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "gopkg.in/yaml.v2"
+  revision = "v2.4.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/swag"
+  revision = "v0.19.15"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/runtime"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/analysis"
+  revision = "v0.20.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonpointer"
+  revision = "v0.19.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/urlesc"
+  revision = "v0.0.0-20170810143723-de5bf2ad4578"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/text"
+  revision = "v0.3.7"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/net"
+  revision = "v0.0.0-20211101193420-4a448f8816b3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/PuerkitoBio/purell"
+  revision = "v1.1.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/jsonreference"
+  revision = "v0.19.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/spec"
+  revision = "v0.20.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/loads"
+  revision = "v0.21.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-openapi/validate"
+  revision = "v0.20.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/opentracing/opentracing-go"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/apiclarity/plugins/api"
+  revision = "v0.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/trace-sampling-manager/api"
+  revision = "v0.0.0-20220503091058-2730f5ebad2c"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/satori/go.uuid"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/openclarity/apiclarity/plugins/common"
+  revision = "v0.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/fsnotify/fsnotify"
+  revision = "v1.5.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-2-Clause"
+  name = "github.com/magiconair/properties"
+  revision = "v1.8.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/spf13/afero"
+  revision = "v1.6.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/spf13/cast"
+  revision = "v1.4.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/spf13/jwalterweatherman"
+  revision = "v1.1.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/spf13/pflag"
+  revision = "v1.0.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/spf13/viper"
+  revision = "v1.9.1-0.20211209175822-a785a79f2240"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MPL-2.0"
+  name = "github.com/hashicorp/hcl"
+  revision = "v1.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/pelletier/go-toml"
+  revision = "v1.9.4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/subosito/gotenv"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "gopkg.in/ini.v1"
+  revision = "v1.65.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "google.golang.org/protobuf"
+  revision = "v1.27.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/golang/protobuf"
+  revision = "v1.5.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/googleapis/gnostic"
+  revision = "v0.5.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "gopkg.in/yaml.v3"
+  revision = "v3.0.0-20210107192922-496545a6307b"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "github.com/gogo/protobuf"
+  revision = "v1.3.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/google/gofuzz"
+  revision = "v1.1.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.92610836
+  license = "BSD-3-Clause"
+  name = "gopkg.in/inf.v0"
+  revision = "v0.9.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "k8s.io/apimachinery"
+  revision = "v0.22.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/google/go-cmp"
+  revision = "v0.5.6"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/go-logr/logr"
+  revision = "v0.4.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "k8s.io/klog/v2"
+  revision = "v2.9.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/modern-go/concurrent"
+  revision = "v0.0.0-20180306012644-bacd9c7ef1dd"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/modern-go/reflect2"
+  revision = "v1.0.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "MIT"
+  name = "github.com/json-iterator/go"
+  revision = "v1.1.11"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "sigs.k8s.io/structured-merge-diff/v4"
+  revision = "v4.1.2"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 0.0
+  license = ""
+  name = "sigs.k8s.io/yaml"
+  revision = "v1.2.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "k8s.io/api"
+  revision = "v0.22.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "k8s.io/client-go"
+  revision = "v0.22.3"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "ISC"
+  name = "github.com/davecgh/go-spew"
+  revision = "v1.1.1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/term"
+  revision = "v0.0.0-20210220032956-6a3ed077a48d"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/oauth2"
+  revision = "v0.0.0-20211005180243-6b3c2da341f1"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "golang.org/x/time"
+  revision = "v0.0.0-20210723032227-1f47c861a9ac"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "k8s.io/utils"
+  revision = "v0.0.0-20210819203725-bdf08cb9a70a"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/imdario/mergo"
+  revision = "v0.3.5"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-2-Clause"
+  name = "github.com/bradleyfalzon/tlsx"
+  revision = "v0.0.0-20170624122154-28fd0e59bac4"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "BSD-3-Clause"
+  name = "github.com/google/gopacket"
+  revision = "v1.1.19"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/up9inc/mizu/shared"
+  revision = "v0.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/google/martian"
+  revision = "v2.1.0+incompatible"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/up9inc/mizu/tap/api"
+  revision = "v0.0.0"
+  type = "gomod"
+
+[[dependencies]]
+  confidence = 1.0
+  license = "Apache-2.0"
+  name = "github.com/up9inc/mizu/tap"
+  revision = "v0.0.0-20211107103142-4badaadcc134"
+  type = "gomod"


### PR DESCRIPTION
This PR:
  * updates the licensei version to the newest 0.6.1
  * moves license cache files to correct location where licensei is run (location of go.mod)
  * fixes Makefile to generate the cache files in the correct location so they can stay updated
