### PR TITLE
Add diffType to spec diff hash 

### DIFF
--- a/backend/pkg/modules/internal/spec_differ/spec_diffs.go
+++ b/backend/pkg/modules/internal/spec_differ/spec_diffs.go
@@ -30,9 +30,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 
-	_spec "github.com/openclarity/speculator/pkg/spec"
-	_speculator "github.com/openclarity/speculator/pkg/speculator"
-
 	"github.com/openclarity/apiclarity/api/server/models"
 	"github.com/openclarity/apiclarity/api3/common"
 	"github.com/openclarity/apiclarity/api3/global"
@@ -41,6 +38,8 @@ import (
 	"github.com/openclarity/apiclarity/backend/pkg/modules/internal/spec_differ/config"
 	"github.com/openclarity/apiclarity/backend/pkg/modules/internal/spec_differ/restapi"
 	speculatorutils "github.com/openclarity/apiclarity/backend/pkg/utils/speculator"
+	_spec "github.com/openclarity/speculator/pkg/spec"
+	_speculator "github.com/openclarity/speculator/pkg/speculator"
 )
 
 type diffHash [32]byte

--- a/backend/pkg/modules/internal/spec_differ/spec_diffs.go
+++ b/backend/pkg/modules/internal/spec_differ/spec_diffs.go
@@ -30,6 +30,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 
+	_spec "github.com/openclarity/speculator/pkg/spec"
+	_speculator "github.com/openclarity/speculator/pkg/speculator"
+
 	"github.com/openclarity/apiclarity/api/server/models"
 	"github.com/openclarity/apiclarity/api3/common"
 	"github.com/openclarity/apiclarity/api3/global"
@@ -38,8 +41,6 @@ import (
 	"github.com/openclarity/apiclarity/backend/pkg/modules/internal/spec_differ/config"
 	"github.com/openclarity/apiclarity/backend/pkg/modules/internal/spec_differ/restapi"
 	speculatorutils "github.com/openclarity/apiclarity/backend/pkg/utils/speculator"
-	_spec "github.com/openclarity/speculator/pkg/spec"
-	_speculator "github.com/openclarity/speculator/pkg/speculator"
 )
 
 type diffHash [32]byte
@@ -183,8 +184,7 @@ func (s *specDiffer) addDiffToSend(diff *_spec.APIDiff, modifiedPathItem, origin
 	newSpec := string(newSpecB)
 	oldSpec := string(oldSpecB)
 
-	// TODO should we include also specType in the hash?
-	hash := sha256.Sum256([]byte(newSpec + oldSpec))
+	hash := sha256.Sum256([]byte(newSpec + oldSpec + string(diffType)))
 
 	apiInfo, err := s.accessor.GetAPIInfo(context.TODO(), event.APIInfoID)
 	if err != nil {

--- a/backend/pkg/modules/internal/spec_differ/spec_diffs.go
+++ b/backend/pkg/modules/internal/spec_differ/spec_diffs.go
@@ -183,7 +183,7 @@ func (s *specDiffer) addDiffToSend(diff *_spec.APIDiff, modifiedPathItem, origin
 	newSpec := string(newSpecB)
 	oldSpec := string(oldSpecB)
 
-	hash := sha256.Sum256([]byte(newSpec + oldSpec + string(diffType)))
+	hash := sha256.Sum256([]byte(newSpec + oldSpec + string(specType)))
 
 	apiInfo, err := s.accessor.GetAPIInfo(context.TODO(), event.APIInfoID)
 	if err != nil {

--- a/backend/pkg/modules/internal/spec_differ/spec_diffs_test.go
+++ b/backend/pkg/modules/internal/spec_differ/spec_diffs_test.go
@@ -157,8 +157,10 @@ func Test_differ_addDiffToSend(t *testing.T) {
 	)
 
 	var (
-		hashV2                = sha256.Sum256([]byte(newSpecV2 + oldSpecV2))
-		hashV3                = sha256.Sum256([]byte(newSpecV3 + oldSpecV3))
+		hashV2Reconstructed = sha256.Sum256([]byte(newSpecV2 + oldSpecV2 + common.RECONSTRUCTED))
+		hashV2Provided      = sha256.Sum256([]byte(newSpecV2 + oldSpecV2 + common.PROVIDED))
+		hashV3Reconstructed = sha256.Sum256([]byte(newSpecV3 + oldSpecV3 + common.RECONSTRUCTED))
+
 		methodGet             = common.GET
 		specTypeReconstructed = common.RECONSTRUCTED
 		specTypeProvided      = common.PROVIDED
@@ -215,7 +217,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 			name: "no diff event - nothing change",
 			fields: fields{
 				apiIDToDiffs: map[uint]map[diffHash]global.Diff{
-					1: {hashV2: global.Diff{
+					1: {hashV2Reconstructed: global.Diff{
 						DiffType:      common.GENERALDIFF,
 						LastSeen:      time.Unix(1234, 0),
 						NewSpec:       newSpecV2,
@@ -233,7 +235,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 				diffType: models.DiffTypeNODIFF,
 			},
 			wantAPIIDToDiffs: map[uint]map[diffHash]global.Diff{
-				1: {hashV2: global.Diff{
+				1: {hashV2Reconstructed: global.Diff{
 					DiffType:      common.GENERALDIFF,
 					LastSeen:      time.Unix(1234, 0),
 					NewSpec:       newSpecV2,
@@ -251,7 +253,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 			name: "event threshold reached - ignoring event",
 			fields: fields{
 				apiIDToDiffs: map[uint]map[diffHash]global.Diff{
-					1: {hashV2: global.Diff{
+					1: {hashV2Reconstructed: global.Diff{
 						DiffType:      common.GENERALDIFF,
 						LastSeen:      time.Unix(1234, 0),
 						NewSpec:       newSpecV2,
@@ -269,7 +271,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 				diffType: models.DiffTypeZOMBIEDIFF,
 			},
 			wantAPIIDToDiffs: map[uint]map[diffHash]global.Diff{
-				1: {hashV2: global.Diff{
+				1: {hashV2Reconstructed: global.Diff{
 					DiffType:      common.GENERALDIFF,
 					LastSeen:      time.Unix(1234, 0),
 					NewSpec:       newSpecV2,
@@ -311,7 +313,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 				}, nil)
 			},
 			wantAPIIDToDiffs: map[uint]map[diffHash]global.Diff{
-				1: {hashV2: global.Diff{
+				1: {hashV2Reconstructed: global.Diff{
 					DiffType:      common.GENERALDIFF,
 					LastSeen:      time.Unix(11, 0),
 					NewSpec:       newSpecV2,
@@ -352,7 +354,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 				}, nil)
 			},
 			wantAPIIDToDiffs: map[uint]map[diffHash]global.Diff{
-				1: {hashV3: global.Diff{
+				1: {hashV3Reconstructed: global.Diff{
 					DiffType:      common.GENERALDIFF,
 					LastSeen:      time.Unix(11, 0),
 					NewSpec:       newSpecV3,
@@ -369,7 +371,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 			name: "event has spec diff - first time for this api id - events map is not empty",
 			fields: fields{
 				apiIDToDiffs: map[uint]map[diffHash]global.Diff{
-					2: {hashV2: global.Diff{
+					2: {hashV2Reconstructed: global.Diff{
 						DiffType:      common.GENERALDIFF,
 						LastSeen:      time.Unix(1234, 0),
 						Method:        methodGet,
@@ -405,7 +407,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 				}, nil)
 			},
 			wantAPIIDToDiffs: map[uint]map[diffHash]global.Diff{
-				1: {hashV2: global.Diff{
+				1: {hashV2Provided: global.Diff{
 					DiffType:      common.GENERALDIFF,
 					LastSeen:      time.Unix(11, 0),
 					NewSpec:       newSpecV2,
@@ -415,7 +417,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 					SpecType:      specTypeProvided,
 					SpecTimestamp: time.Unix(13, 0),
 				}},
-				2: {hashV2: global.Diff{
+				2: {hashV2Reconstructed: global.Diff{
 					DiffType:      common.GENERALDIFF,
 					LastSeen:      time.Unix(1234, 0),
 					NewSpec:       newSpecV2,
@@ -432,7 +434,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 			name: "event has spec diff - already exists for this api id - update last seen - don't increase total",
 			fields: fields{
 				apiIDToDiffs: map[uint]map[diffHash]global.Diff{
-					1: {hashV2: global.Diff{
+					1: {hashV2Provided: global.Diff{
 						DiffType:      common.GENERALDIFF,
 						LastSeen:      time.Unix(11, 0),
 						NewSpec:       newSpecV2,
@@ -468,7 +470,7 @@ func Test_differ_addDiffToSend(t *testing.T) {
 				}, nil)
 			},
 			wantAPIIDToDiffs: map[uint]map[diffHash]global.Diff{
-				1: {hashV2: global.Diff{
+				1: {hashV2Provided: global.Diff{
 					DiffType:      common.GENERALDIFF,
 					LastSeen:      time.Unix(12, 0),
 					NewSpec:       newSpecV2,


### PR DESCRIPTION
Add diffType to spec diff hash to make sure that reconstructed spec diffs will not override provided spec diffs