### PR TITLE
allow APIClarity to start without kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Update [values.yaml](https://github.com/openclarity/apiclarity/blob/master/chart
    DATABASE_DRIVER=LOCAL K8S_LOCAL=true FAKE_TRACES=true FAKE_TRACES_PATH=./backend/pkg/test/trace_files \
    ENABLE_DB_INFO_LOGS=true ./backend/bin/backend run
    ```
+   Note: this command requires a proper KUBECONFIG in your environment when __K8S_LOCAL=true__ is used. If you want to run without k8s, use __ENABLE_K8S=false__ instead.
 
 4. Open APIClarity UI in the browser: <http://localhost:8080/>
 

--- a/backend/cmd/backend/main.go
+++ b/backend/cmd/backend/main.go
@@ -56,6 +56,7 @@ func main() {
 	viper.SetDefault(config.DatabaseCleanerIntervalSec, "30")
 	viper.SetDefault(config.StateBackupFileName, "state.gob")
 	viper.SetDefault(config.DatabaseDriver, database.DBDriverTypePostgres)
+	viper.SetDefault(config.EnableK8s, true)
 	viper.SetDefault(config.TLSServerCertFilePath, "/etc/certs/server.crt")
 	viper.SetDefault(config.TLSServerKeyFilePath, "/etc/certs/server.key")
 	viper.SetDefault(config.RootCertFilePath, "/etc/root-ca/ca.crt")

--- a/backend/pkg/backend/backend.go
+++ b/backend/pkg/backend/backend.go
@@ -124,7 +124,7 @@ func Run() {
 	dbHandler.StartReviewTableCleaner(globalCtx, time.Duration(config.DatabaseCleanerIntervalSec)*time.Second)
 	var clientset kubernetes.Interface
 	var monitor *k8smonitor.Monitor
-	var samplingManager *manager.Manager = nil
+	var samplingManager *manager.Manager
 	if config.EnableK8s {
 		if config.K8sLocal {
 			clientset, err = k8smonitor.CreateLocalK8sClientset()

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -43,6 +43,7 @@ const (
 	StateBackupFileName           = "STATE_BACKUP_FILE_NAME"
 	NoMonitorEnvVar               = "NO_K8S_MONITOR"
 	K8sLocalEnvVar                = "K8S_LOCAL"
+	EnableK8s                     = "ENABLE_K8S"
 	EnableTLS                     = "ENABLE_TLS"
 	TLSServerCertFilePath         = "TLS_SERVER_CERT_FILE_PATH"
 	TLSServerKeyFilePath          = "TLS_SERVER_KEY_FILE_PATH"
@@ -75,6 +76,7 @@ type Config struct {
 	StateBackupFileName        string
 	SpeculatorConfig           _speculator.Config
 	K8sLocal                   bool
+	EnableK8s                  bool
 	EnableTLS                  bool
 	TLSServerCertFilePath      string
 	TLSServerKeyFilePath       string
@@ -125,6 +127,7 @@ func LoadConfig() (*Config, error) {
 	config.NotificationPrefix = viper.GetString(NotificationPrefix)
 
 	config.K8sLocal = viper.GetBool(K8sLocalEnvVar)
+	config.EnableK8s = viper.GetBool(EnableK8s)
 	config.EnableTLS = viper.GetBool(EnableTLS)
 	config.DatabaseDriver = viper.GetString(DatabaseDriver)
 	config.DBPassword = viper.GetString(DBPasswordEnvVar)

--- a/backend/pkg/modules/internal/core/core.go
+++ b/backend/pkg/modules/internal/core/core.go
@@ -120,14 +120,11 @@ func shouldTrace(host string, port int64, hosts []string) bool {
 }
 
 func (c *Core) EventNotify(ctx context.Context, event *Event) {
-	if !c.traceSamplingEnabled {
-		return
-	}
 	host := event.APIEvent.HostSpecName
 	port := event.APIEvent.DestinationPort
 
 	for modName, mod := range c.Modules {
-		if !shouldTrace(host, port, c.samplingManager.HostsToTraceByComponentID(modName)) {
+		if c.traceSamplingEnabled && !shouldTrace(host, port, c.samplingManager.HostsToTraceByComponentID(modName)) {
 			log.Debugf("Trace of host %s should NOT be sent to module %s.", host, modName)
 			continue
 		}

--- a/backend/pkg/modules/internal/core/core.go
+++ b/backend/pkg/modules/internal/core/core.go
@@ -61,10 +61,11 @@ func RegisterModule(m ModuleFactory) {
 
 type ModuleFactory func(ctx context.Context, accessor BackendAccessor) (Module, error)
 
-func New(ctx context.Context, accessor BackendAccessor, samplingManager *manager.Manager) (Module, []ModuleInfo) {
+func New(ctx context.Context, accessor BackendAccessor, samplingManager *manager.Manager, traceSamplingEnabled bool) (Module, []ModuleInfo) {
 	c := &Core{}
 	c.Modules = map[string]Module{}
 	c.samplingManager = samplingManager
+	c.traceSamplingEnabled = traceSamplingEnabled
 
 	modInfos := []ModuleInfo{}
 	for moduleFolderName, moduleFactory := range modules {
@@ -84,8 +85,9 @@ func New(ctx context.Context, accessor BackendAccessor, samplingManager *manager
 }
 
 type Core struct {
-	Modules         map[string]Module
-	samplingManager *manager.Manager
+	Modules              map[string]Module
+	samplingManager      *manager.Manager
+	traceSamplingEnabled bool
 }
 
 func (c *Core) Info() ModuleInfo {
@@ -118,6 +120,9 @@ func shouldTrace(host string, port int64, hosts []string) bool {
 }
 
 func (c *Core) EventNotify(ctx context.Context, event *Event) {
+	if !c.traceSamplingEnabled {
+		return
+	}
 	host := event.APIEvent.HostSpecName
 	port := event.APIEvent.DestinationPort
 

--- a/backend/pkg/modules/modules.go
+++ b/backend/pkg/modules/modules.go
@@ -62,7 +62,7 @@ func New(ctx context.Context, dbHandler *database.Handler, clientset kubernetes.
 		return nil, nil, fmt.Errorf("failed to create backend accessor: %v", err)
 	}
 
-	module, infos := core.New(ctx, backendAccessor, samplingManager)
+	module, infos := core.New(ctx, backendAccessor, samplingManager, config.TraceSamplingEnabled)
 
 	return module, infos, nil
 }


### PR DESCRIPTION
This PR provides a new config flag to start APIClarity without kubernetes.

  * A new boolean env var "ENABLE_K8S" is checked at boot.
  * The env var "TRACE_SAMPLING_ENABLED" configuration is enforced by disabling the trace-sampling-manager.

By default the env var *ENABLE_K8S* is set to __True__, allowing backwards-compatible behavior with existing deployments.

Since the trace-sampling-manager still requires k8s to store some data, the PR also includes a change to disable the trace sampling manager when *TRACE_SAMPLING_ENABLED* is __False__. This may cause backward-compatibility problems as the behavior can be different in edge cases.

So, realistically, to boot APIClarity cleanly without k8s, you must use the following config and this PR:
  * ENABLE_K8S=False
  * TRACE_SAMPLING_ENABLED=False