### PR TITLE
Helm: adds auth trace server service

### DIFF
--- a/charts/apiclarity/templates/service.yaml
+++ b/charts/apiclarity/templates/service.yaml
@@ -18,6 +18,10 @@ spec:
       port: 9443
       protocol: TCP
       targetPort: 9443
+    - name: https-authenticated-trace-server
+      port: 10443
+      protocol: TCP
+      targetPort: 10443
 {{- end }}
     - name: http-backend
       port: 8080


### PR DESCRIPTION
If tls is enabled, the external, authenticated trace server is started on port 10443.