### PR TITLE
tracing sampling return value update

### DIFF
--- a/backend/pkg/database/apievent.go
+++ b/backend/pkg/database/apievent.go
@@ -272,7 +272,6 @@ func (a *APIEventsTableHandler) GetAPIEventsWithAnnotations(ctx context.Context,
 	}
 
 	if err := tx.Offset(query.Offset).
-		Limit(query.Limit).
 		Order(fmt.Sprintf("%s %s", query.Order, sortDir)).
 		WithContext(ctx).
 		Find(&events).Error; err != nil {

--- a/backend/pkg/database/apievent.go
+++ b/backend/pkg/database/apievent.go
@@ -271,6 +271,10 @@ func (a *APIEventsTableHandler) GetAPIEventsWithAnnotations(ctx context.Context,
 		sortDir = "ASC"
 	}
 
+	if query.Limit != 0 {
+		tx = tx.Limit(query.Limit)
+	}
+
 	if err := tx.Offset(query.Offset).
 		Order(fmt.Sprintf("%s %s", query.Order, sortDir)).
 		WithContext(ctx).

--- a/backend/pkg/modules/internal/core/modules.go
+++ b/backend/pkg/modules/internal/core/modules.go
@@ -17,7 +17,6 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -241,7 +240,7 @@ func (b *accessor) Notify(ctx context.Context, modName string, apiID uint, n not
 
 func (b *accessor) EnableTraces(ctx context.Context, modName string, apiID uint) error {
 	if !b.traceSamplingEnabled {
-		return errors.New("trace sampling is not enabled")
+		return nil
 	}
 	if err := b.samplingManager.AddHostToTrace(modName, uint32(apiID)); err != nil {
 		return fmt.Errorf("failed to add API %v to trace: %v", apiID, err)


### PR DESCRIPTION
fix: ignore trace enablement commands when trace sampling is disabled instead of throwing an error