### PR TITLE
Add granular permissions to GitHub action workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,9 @@ on:
 env:
   OTEL_COLLECTOR_VERSION: 0.60.0
 
+permissions:
+  packages: write
+
 jobs:
   docker:
     name: Docker

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,10 @@ env:
   GO_VERSION: 1.17
   OTEL_COLLECTOR_VERSION: 0.60.0
 
+permissions:
+  packages: write
+  contents: write
+
 jobs:
   verification:
     runs-on: ubuntu-latest


### PR DESCRIPTION
same as https://github.com/openclarity/kubeclarity/commit/cbbfee3e29379233fd5c24ed5f16ecfa21a0da33

This commit adds granular permissions to the workflows that need them to
perform their tasks.

The release action needs access to the "contents" of a repo in order to
create a release, and requires access to packages in order to publish
the containers.

The docker action only needs access to packages to publish the
"latest" build from the main branch.